### PR TITLE
Updated frontier readme for OmniperfExamples

### DIFF
--- a/OmniperfExamples/README-Frontier-users.md
+++ b/OmniperfExamples/README-Frontier-users.md
@@ -2,6 +2,7 @@
 
 To load the appropriate environment, you should be able to simply run:
 ```
+module use /autofs/nccs-svm1_sw/crusher/amdsw/modules
 module load PrgEnv-amd amd omniperf/1.1.0-PR1
 ```
 This should pull in Omniperf, ROCm, and all the dependencies necessary to run our exercises.


### PR DESCRIPTION
Now updated with `module use` that loads more recent omniperf builds.