### PR TITLE
Update GhostExchange.cc with dummy target region.

### DIFF
--- a/MPI-examples/GhostExchange/GhostExchange_ArrayAssign/Ver4/GhostExchange.cc
+++ b/MPI-examples/GhostExchange/GhostExchange_ArrayAssign/Ver4/GhostExchange.cc
@@ -103,6 +103,10 @@ int main(int argc, char *argv[])
    int jnum = jhgh-jlow;
    int bufcount = jnum*nhalo;
 
+   // smoke test.  
+   #pragma omp target
+   {}
+
    roctxRangePush("BufAlloc");
    xbuf_left_send = (double *)malloc(bufcount*sizeof(double));
    xbuf_rght_send = (double *)malloc(bufcount*sizeof(double));


### PR DESCRIPTION
Add target region for OpenMP smoke test right before the relevant ROCTX ranges are created. OMPT needs to be enabled for the example to be more robust against tool issues and the ranges properly captured.