### PR TITLE
Update GhostExchange.cc with smoke tests target region.

### DIFF
--- a/MPI-examples/GhostExchange/GhostExchange_ArrayAssign/Ver6/GhostExchange.cc
+++ b/MPI-examples/GhostExchange/GhostExchange_ArrayAssign/Ver6/GhostExchange.cc
@@ -108,6 +108,9 @@ int main(int argc, char *argv[])
    int jnum = jhgh-jlow;
    int bufcount = jnum*nhalo;
 
+   #pragma omp target
+   {}
+
    roctxRangePush("BufAlloc");
    xbuf_left_send = (double *)malloc(bufcount*sizeof(double));
    xbuf_rght_send = (double *)malloc(bufcount*sizeof(double));


### PR DESCRIPTION
ROCTX are captured properly if they happen after the first OpenMP activity. This is meant to make this example more robust.