### PR TITLE
Remove -DNDEBUG from Makefile

### DIFF
--- a/OmniperfExamples/3-RegisterOccupancyLimit/Makefile
+++ b/OmniperfExamples/3-RegisterOccupancyLimit/Makefile
@@ -6,7 +6,7 @@ all: $(EXECUTABLE)
 OBJECTS = problem.o
 ROCM_GPU ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
 CXXFLAGS = -g -O2 -DNDEBUG -fPIC
-HIPCC_FLAGS = --offload-arch=$(ROCM_GPU) -g -O2 -DNDEBUG
+HIPCC_FLAGS = --offload-arch=$(ROCM_GPU) -g -O2
 
 HIP_PLATFORM ?= amd
 


### PR DESCRIPTION
-DNDEBUG disables the assert which is the trigger of the problem. This makefile should not have this macro defined as does the solution makefile.