### PR TITLE
Some changes to the exercises repo

### DIFF
--- a/HIP/README.md
+++ b/HIP/README.md
@@ -1,8 +1,3 @@
---------------------------------------------------------------
-
-\pagebreak{}
-
-
 # Introduction to HIP Exercises
 
 **NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.

--- a/HIP/README.md
+++ b/HIP/README.md
@@ -1,0 +1,117 @@
+--------------------------------------------------------------
+
+\pagebreak{}
+
+
+# Introduction to HIP Exercises
+
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
+
+`git clone https://github.com/amd/HPCTrainingExamples.git`
+
+For the first interactive example, get an slurm interactive session
+
+`salloc -N 1 -p LocalQ --gpus=1 -t 10:00`
+
+## Basic examples
+
+`cd HPCTrainingExamples/HIP/vectorAdd `
+
+Examine files here - README, Makefile, CMakeLists.txt and vectoradd.hip. Notice that Makefile requires `ROCM_PATH` to be set. Check with module show rocm or echo `$ROCM_PATH` Also, the Makefile builds and runs the code. We'll do the steps separately. Check also the HIPFLAGS in the Makefile. There is also a CMakeLists.txt file to use for a cmake build.
+
+For the portable Makefile system
+```bash
+module load rocm
+
+make vectoradd
+./vectoradd
+```
+
+Pro tip for Makefile builds. Run `make clean` before `make` to be sure nothing is left over from a previous build.
+
+This example also runs with the cmake system
+
+```bash
+module load rocm
+
+mkdir build && cd build
+cmake ..
+make
+./vectoradd
+```
+
+Pro tip for cmake builds. To rebuild after changing CMake options or using a different compiler, either
+
+* Remove the CMakeCache.txt, or
+* clean out all files from the ./build directory
+
+We can use a SLURM submission script, let's call it `hip_batch.sh`. There is a sample script for some systems in the example directory.
+
+```bash
+#!/bin/bash
+#SBATCH -N 1
+#SBATCH -p LocalQ
+#SBATCH --gpus=1
+#SBATCH -t 10:00
+
+module load rocm
+cd $HOME/HPCTrainingExamples/HIP/vectorAdd 
+
+make vectoradd
+./vectoradd
+```
+
+Submit the script
+`sbatch hip_batch.sh`
+
+Check for output in `slurm-<job-id>.out` or error in `slurm-<job-id>.err`
+
+To use the cmake option in the batch file, change the build to
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+./vectoradd
+```
+
+Now let's try the hip-stream example. This example is from the original McCalpin code as ported to CUDA by Nvidia. This version has been ported to use HIP.
+
+```bash
+module load rocm
+cd $HOME/HPCTrainingExamples/HIP/hip-stream
+make
+./stream
+```
+Note that it builds with the hipcc compiler. You should get a report of the Copy, Scale, Add, and Triad cases.
+
+On your own:
+
+1. Check out the saxpy example in `HPCTrainingExamples/HIP`
+2. Write your own kernel and run it
+3. Test the code on an Nvidia system -- Add `HIPCC=nvcc` before the make command or `-DCMAKE_GPU_RUNTIME=CUDA` to the cmake command. (See README file)
+
+## More advanced HIP makefile
+
+The jacobi example has a more complex build that incorporates MPI. The original Makefile has not been modified, but a CMakeLists.txt has been added to demonstrate a portable cmake build. From an interactive session, build the example.
+
+
+```bash
+cd $HOME/HPCTrainingExamples/HIP/jacobi
+
+module load rocm
+module load openmpi
+
+mkdir build && cd build
+cmake ..
+make
+```
+
+Since we will be running on two MPI ranks, you will need to alloc 2 GPUs for a quick run. Exit your current allocation with `exit` and then get the two GPUs. Keep the requested time short to avoid tying up the GPUs so others can run the examples. The requested time shown is in the format hours:minutes:seconds so it is for one minute.
+
+```bash 
+salloc -p LocalQ --gpus=2 -n 2 -t 00:01:00
+module load rocm openmpi
+mpirun -n 2 ./Jacobi_hip -g 2
+```

--- a/HIPIFY/README.md
+++ b/HIPIFY/README.md
@@ -1,0 +1,466 @@
+# Porting Applications to HIP
+
+## Hipify Examples
+
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
+
+### Exercise 1: Manual code conversion from CUDA to HIP (10 min)
+
+Choose one or more of the CUDA samples in `HPCTrainingExamples/HIPIFY/mini-nbody/cuda` directory. Manually convert it to HIP. Tip: for example, the cudaMalloc will be called hipMalloc.
+You can choose from `nbody-block.cu, nbody-orig.cu, nbody-soa.cu`
+
+You'll want to compile on the node you've been allocated so that hipcc will choose the correct GPU architecture.
+
+### Exercise 2: Code conversion from CUDA to HIP using HIPify tools (10 min)
+
+Use the `hipify-perl` script to "hipify" the CUDA samples you used to manually convert to HIP in Exercise 1. hipify-perl is in `$ROCM_PATH/hip/bin` directory and should be in your path.
+
+First test the conversion to see what will be converted
+```bash
+hipify-perl -examine nbody-orig.cu
+```
+
+You'll see the statistics of HIP APIs that will be generated. The output might be different depending on the ROCm version.
+```bash
+[HIPIFY] info: file 'nbody-orig.cu' statistics:
+  CONVERTED refs count: 7
+  TOTAL lines of code: 91
+  WARNINGS: 0
+[HIPIFY] info: CONVERTED refs by names:
+  cudaFree => hipFree: 1
+  cudaMalloc => hipMalloc: 1
+  cudaMemcpyDeviceToHost => hipMemcpyDeviceToHost: 1
+  cudaMemcpyHostToDevice => hipMemcpyHostToDevice: 1
+```
+
+`hipify-perl` is in `$ROCM_PATH/hip/bin` directory and should be in your path. In some versions of ROCm, the script is called `hipify-perl`.
+
+Now let's actually do the conversion.
+```bash
+hipify-perl nbody-orig.cu > nbody-orig.cpp
+```
+
+Compile the HIP programs.
+
+```bash
+hipcc -DSHMOO -I ../ nbody-orig.cpp -o nbody-orig
+```
+
+The `#define SHMOO` fixes some timer printouts. Add `--offload-arch=<gpu_type>` to specify the GPU type and avoid the autodetection issues when running on a single GPU on a node.
+
+* Fix any compiler issues, for example, if there was something that didn't hipify correctly.
+* Be on the lookout for hard-coded Nvidia specific things like warp sizes and PTX.
+
+Run the program
+
+```bash
+./nbody-orig
+```
+
+A batch version of Exercise 2 is:
+
+```bash
+#!/bin/bash
+#SBATCH -N 1
+#SBATCH --ntasks=1
+#SBATCH --gpus=1
+#SBATCH -p LocalQ
+#SBATCH -t 00:10:00
+
+pwd
+module load rocm
+
+cd HPCTrainingExamples/HIPIFY/mini-nbody/cuda
+hipify-perl -print-stats nbody-orig.cu > nbody-orig.cpp
+hipcc -DSHMOO -I ../ nbody-orig.cpp -o nbody-orig
+./nbody-orig
+
+```
+
+Notes:
+
+* Hipify tools do not check correctness
+* `hipconvertinplace-perl` is a convenience script that does `hipify-perl -inplace -print-stats` command
+
+### Mini-App conversion example
+
+Load the proper environment
+
+```bash
+cd $HOME/HPCTrainingExamples/HIPFY/
+module load rocm
+```
+
+Get the CUDA version of the Pennant mini-app.
+
+```bash
+wget https://asc.llnl.gov/sites/asc/files/2020-09/pennant-singlenode-cude.tgz
+tar -xzvf pennant-singlenode-cude.tgz
+
+cd PENNANT
+
+hipexamine-perl.sh
+```
+
+And review the output
+
+Now do the actual conversion. We want to do the conversion for the whole directory tree, so we'll use hipconvertinplace-sh
+
+```bash
+hipconvertinplace-perl.sh
+```
+
+We want to use `.hip` extensions rather than `.cu`, so change all files with `.cu` to `.hip`
+
+```bash
+mv src/HydroGPU.cu src/HydroGPU.hip
+```
+
+Now we have two options to convert the build system to work with both ROCm and CUDA
+
+## Makefile option
+
+First cut at converting the Makefile. Testing with `make` can help identify the next step.
+
+* Change all occurances of CUDA to HIP
+        (e.g.   sed -i 's/cuda/hip/g' Makefile)
+* Change the CXX variable to `clang++` located in `${ROCM_PATH}/llvm/bin/clang++`
+* Change all the HIPC variables to HIPCC
+* Change HIPCC to point to hipcc
+* Change HIPCCFLAGS with CUDA options to HIPCCFLAGS\_CUDA
+* Remove `-fast` and `-fno-alias` from the CXXFLAGS\_OPT
+* Change all `.cu` to `.hip` in the Makefile
+
+Now we are just getting compile errors from the source files. We will have to do fixes there. We'll tackle them one-by-one.
+
+The first errors are related to the double2 type.
+
+```bash
+compiling src/HydroGPU.hip
+(CPATH=;hipcc -O3 -I.  -c -o build/HydroGPU.o src/HydroGPU.hip)
+In file included from src/HydroGPU.hip:14:
+In file included from src/HydroGPU.hh:16:
+```
+`src/Vec2.hh:35:8: error: definition of type 'double2' conflicts with type alias of the same name`
+```
+
+struct double2
+       ^
+```
+
+`/opt/rocm-5.6.0/include/hip/amd_detail/amd_hip_vector_types.h:1098:1: note: 'double2' declared here`
+
+```
+__MAKE_VECTOR_TYPE__(double, double);
+
+^
+```
+
+`/opt/rocm-5.6.0/include/hip/amd_detail/amd_hip_vector_types.h:1062:15: note: expanded from macro '__MAKE_VECTOR_TYPE__'`
+
+```
+        using CUDA_name##2 = HIP_vector_type<T, 2>;\
+
+              ^
+<scratch space>:316:1: note: expanded from here
+double2
+```
+
+HIP defines double2. Let's look at Vec2.hh. At line 33 where the first error occurs. We see an `#ifdef __CUDACC__` around a block of code there. We also need the #ifdef to include HIP as well. Let's check the available compiler defines from the presentation to see what is available. It looks like we can use `__HIP_DEVICE_COMPILE__` or maybe `__HIPCC__`.
+
+Change line 33 in Vec2.hh to #ifndef `__HIPCC__`
+
+The next error is about function attributes that are incorrect for device code. 
+
+
+```bash
+compiling src/HydroGPU.hip
+(CPATH=;hipcc -O3 -I.  -c -o build/HydroGPU.o src/HydroGPU.hip
+src/HydroGPU.hip:168:23: error: no matching function for call to 'cross
+    double sa = 0.5 * cross(px[p2] - px[p1],  zx[z] - px[p1]);
+                      ^~~~
+```
+
+`src/Vec2.hh:206:15: note: candidate function not viable: call to __host__ function from __device__ function`
+
+
+The FNQUALIFIER macro is what handles the attributes in the code. We find that defined at line 22 and again we see a `#ifdef __CUDACC__`. It is another `#ifdef __CUDACC__`. We can see that we need to pay attention to all the CUDA ifdef statements.
+
+Change line 22 to `#ifdef __HIPCC__`
+
+
+Finally we get an error about already defined operators on double2 types. These appear to be defined in HIP, but not in CUDA. So we change line 84
+
+```bash
+compiling src/HydroGPU.hip
+(CPATH=;hipcc -O3 -I.  -c -o build/HydroGPU.o src/HydroGPU.hip)
+```
+
+`src/HydroGPU.hip:149:15: error: use of overloaded operator '+=' is ambiguous (with operand types 'double2' (aka 'HIP_vector_type<double, 2>') and 'double2')`
+
+```
+        zxtot += ctemp2[sn];
+        ~~~~~ ^  ~~~~~~~~~~
+/opt/rocm-5.6.0/include/hip/amd_detail/amd_hip_vector_types.h:510:26: note: candidate function
+        HIP_vector_type& operator+=(const HIP_vector_type& x) noexcept
+                         ^
+src/Vec2.hh:88:17: note: candidate function
+inline double2& operator+=(double2& v, const double2& v2)
+```
+
+Change line 85 to `#elif defined(__CUDACC__)`
+
+Now we start getting errors for HydroGPU.hip. The first is for the atomicMin function. It is already defined in HIP, so we need to add an ifdef for CUDA around the code.
+
+```bash
+compiling src/HydroGPU.hip
+(CPATH=;hipcc -O3 -I.  -c -o build/HydroGPU.o src/HydroGPU.hip)
+src/HydroGPU.hip:725:26: error: static declaration of 'atomicMin' follows non-static declaration
+static __device__ double atomicMin(double* address, double val)
+                         ^
+/opt/rocm-5.6.0/include/hip/amd_detail/amd_hip_atomic.h:478:8: note: previous definition is here
+double atomicMin(double* addr, double val) {                                                                                                                          ^
+       ^
+1 error generated when compiling for gfx90a.
+```
+
+Add `#ifdef __CUDACC__/endif` to the more block of code in `HydroGPU.hip` from line 725 to 737
+
+We finally got through the compiler errors and move on to link errors
+
+```bash
+linking build/pennant
+```
+
+`/opt/rocm-5.6.0//llvm/bin/clang++ -o build/pennant build/ExportGold.o build/ImportGMV.o build/Parallel.o build/WriteXY.o build/HydroBC.o build/QCS.o build/TTS.o build/main.o build/Mesh.o build/InputFile.o build/GenMesh.o build/Driver.o build/Hydro.o build/PolyGas.o build/HydroGPU.o -L/lib64 -lcudart`
+
+```
+ld.lld: error: unable to find library -lcudart
+```
+
+In the Makefile, change the LDFLAGS while keeping the old settings for when we set up the switch between GPU platforms.
+
+```bash
+LDFLAGS_CUDA := -L$(HIP_INSTALL_PATH)/lib64 -lcudart
+LDFLAGS := -L${ROCM_PATH}/hip/lib -lamdhip64
+```
+We then get the link error
+
+```bash
+linking build/pennant
+```
+
+`/opt/rocm-5.6.0//llvm/bin/clang++ -o build/pennant build/ExportGold.o build/ImportGMV.o build/Parallel.o build/WriteXY.o build/HydroBC.o build/QCS.o build/TTS.o build/main.o build/Mesh.o build/InputFile.o build/GenMesh.o build/Driver.o build/Hydro.o build/PolyGas.o build/HydroGPU.o -L/opt/rocm-5.6.0//hip/lib -lamdhip64`
+
+`ld.lld: error: undefined symbol: hydroInit(int, int, int, int, int, double, double, double, double, double, double, double, double, double, int, double const*, int, double const*, double2 const*, double2 const*, double const*, double const*, double const*, double const*, double const*, double const*, double const*, int const*, int const*, int const*, int const*, int const*, int const*)`
+
+```
+>>> referenced by Hydro.cc
+>>>               build/Hydro.o:(Hydro::Hydro(InputFile const*, Mesh*))
+
+ld.lld: error: undefined symbol: hydroGetData(int, int, double2*, double*, double*, double*)
+>>> referenced by Hydro.cc
+>>>               build/Hydro.o:(Hydro::getData())
+```
+
+This one is a little harder. We can get more information by using `nm build/Hydro.o |grep hydroGetData` and `nm build/HydroGPU.o |grep hydroGetData`. We can see that the subroutine signatures are slightly different due to the double2 type on the host and GPU. You can also switch the compiler from clang++ to g++ to get a slightly more informative error. We are in a tough spot here because we need the hipmemcpy in the body of the subroutine, but the types for double2 are for the device instead of the host. One solution is to just compile and link everything with hipcc, but we really don't want to do that if only one routine needs to use the device compiler. So we cheat by declaring the prototype arguments as `void *` and casting the type in the call with `(void *)`. The types are really the same and it is just arguing with the compiler.
+
+```bash
+nm build/Hydro.o |grep hydroGetData
+                 U _Z12hydroGetDataiiP7double2PdS1_S1_
+nm build/HydroGPU.o |grep hydroGetData
+0000000000003750 T _Z12hydroGetDataiiP15HIP_vector_typeIdLj2EEPdS2_S2_
+```
+
+In HydroGPU.hh
+
+* Change line 38 and 39 to from `const double2*` to `const void*`
+* Change line 62 from `double2*` to `void*`
+
+In HydroGPU.hip
+
+* Change line 1031 and 1032 to `const void*`
+* Change line 1284 to `const void*`
+
+In Hydro.cc
+
+* Add `(void *)` before the arguments on lines 59, 60, and 145
+
+Now it compiles and we can test the run with
+
+```bash
+build/pennant test/sedovbig/sedovbig.pnt
+```
+
+So we have the code converted to HIP and fixed the build system for it. But we haven't accomplished our original goal of running with both ROCm and CUDA.
+
+We can copy a sample portable Makefile from `HPCTrainingExamples/HIP/saxpy/Makefile` and modify it for this application.
+
+
+```bash
+EXECUTABLE = pennant
+BUILDDIR := build
+SRCDIR = src
+all: $(BUILDDIR)/$(EXECUTABLE) test
+
+.PHONY: test
+
+OBJECTS =  $(BUILDDIR)/Driver.o $(BUILDDIR)/GenMesh.o $(BUILDDIR)/HydroBC.o
+OBJECTS += $(BUILDDIR)/ImportGMV.o $(BUILDDIR)/Mesh.o $(BUILDDIR)/PolyGas.o
+OBJECTS += $(BUILDDIR)/TTS.o $(BUILDDIR)/main.o $(BUILDDIR)/ExportGold.o
+OBJECTS += $(BUILDDIR)/Hydro.o $(BUILDDIR)/HydroGPU.o $(BUILDDIR)/InputFile.o
+OBJECTS += $(BUILDDIR)/Parallel.o $(BUILDDIR)/QCS.o $(BUILDDIR)/WriteXY.o
+
+CXXFLAGS = -g -O3
+HIPCC_FLAGS = -O3 -g -DNDEBUG
+
+HIPCC ?= hipcc
+
+ifeq ($(HIPCC), nvcc)
+   HIPCC_FLAGS += -x cu
+   LDFLAGS = -lcudadevrt -lcudart_static -lrt -lpthread -ldl
+endif
+ifeq ($(HIPCC), hipcc)
+   HIPCC_FLAGS += -munsafe-fp-atomics
+   LDFLAGS = -L${ROCM_PATH}/hip/lib -lamdhip64
+endif
+
+$(BUILDDIR)/%.d : $(SRCDIR)/%.cc
+	@echo making depends for $<
+	$(maketargetdir)
+	@$(CXX) $(CXXFLAGS) $(CXXINCLUDES) -M $< | sed "1s![^ \t]\+\.o!$(@:.d=.o) $@!" >$@
+
+$(BUILDDIR)/%.d : $(SRCDIR)/%.hip
+	@echo making depends for $<
+	$(maketargetdir)
+	@$(HIPCC) $(HIPCCFLAGS) $(HIPCCINCLUDES) -M $< | sed "1s![^ \t]\+\.o!$(@:.d=.o) $@!" >$@
+
+$(BUILDDIR)/%.o : $(SRCDIR)/%.cc
+	@echo compiling $<
+	$(maketargetdir)
+	$(CXX) $(CXXFLAGS) $(CXXINCLUDES) -c -o $@ $<
+
+$(BUILDDIR)/%.o : $(SRCDIR)/%.hip
+	@echo compiling $<
+	$(maketargetdir)
+	$(HIPCC) $(HIPCC_FLAGS) -c $^ -o $@
+
+$(BUILDDIR)/$(EXECUTABLE) : $(OBJECTS)
+	@echo linking $@
+	$(maketargetdir)
+	$(CXX) $(OBJECTS) $(LDFLAGS) -o $@
+
+test : $(BUILDDIR)/$(EXECUTABLE)
+	$(BUILDDIR)/$(EXECUTABLE) test/sedovbig/sedovbig.pnt
+
+define maketargetdir
+	-@mkdir -p $(dir $@) > /dev/null 2>&1
+endef
+
+clean :
+	rm -rf $(BUILDDIR)
+```
+
+To test the makefile,
+
+```bash
+make build/pennant
+make test
+```
+or just `make` to both build and run the test
+
+To test the makefile build system with CUDA (note that the system used for this training does not have CUDA installed so this exercise is left to the student)
+
+```bash
+module load cuda
+HIPCC=nvcc CXX=g++ make
+```
+
+To create a cmake build system, we can copy a sample portable CMakeLists.txt and modify it for this applicaton.
+
+`HPCTrainingExamples/HIP/saxpy/CMakeLists.txt`
+
+```CMake
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(Pennant LANGUAGES CXX)
+include(CTest)
+
+set (CMAKE_CXX_STANDARD 14)
+
+if (NOT CMAKE_BUILD_TYPE)
+   set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif(NOT CMAKE_BUILD_TYPE)
+
+string(REPLACE -O2 -O3 CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+
+if (NOT CMAKE_GPU_RUNTIME)
+   set(GPU_RUNTIME "ROCM" CACHE STRING "Switches between ROCM and CUDA")
+else (NOT CMAKE_GPU_RUNTIME)
+   set(GPU_RUNTIME "${CMAKE_GPU_RUNTIME}" CACHE STRING "Switches between ROCM and CUDA")
+endif (NOT CMAKE_GPU_RUNTIME)
+# Really should only be ROCM or CUDA, but allowing HIP because it is the currently built-in option
+set(GPU_RUNTIMES "ROCM" "CUDA" "HIP")
+if(NOT "${GPU_RUNTIME}" IN_LIST GPU_RUNTIMES)
+    set(ERROR_MESSAGE "GPU_RUNTIME is set to \"${GPU_RUNTIME}\".\nGPU_RUNTIME must be either HIP, 
+        ROCM, or CUDA.")
+    message(FATAL_ERROR ${ERROR_MESSAGE})
+endif()
+# GPU_RUNTIME for AMD GPUs should really be ROCM, if selecting AMD GPUs
+# so manually resetting to HIP if ROCM is selected
+if (${GPU_RUNTIME} MATCHES "ROCM")
+   set(GPU_RUNTIME "HIP")
+endif (${GPU_RUNTIME} MATCHES "ROCM")
+set_property(CACHE GPU_RUNTIME PROPERTY STRINGS ${GPU_RUNTIMES})
+
+enable_language(${GPU_RUNTIME})
+set(CMAKE_${GPU_RUNTIME}_EXTENSIONS OFF)
+set(CMAKE_${GPU_RUNTIME}_STANDARD_REQUIRED ON)
+
+set(PENNANT_CXX_SRCS src/Driver.cc src/ExportGold.cc src/GenMesh.cc src/Hydro.cc src/HydroBC.cc
+                     src/ImportGMV.cc src/InputFile.cc src/Mesh.cc src/Parallel.cc src/PolyGas.cc
+                     src/QCS.cc src/TTS.cc src/WriteXY.cc src/main.cc)
+
+set(PENNANT_HIP_SRCS src/HydroGPU.hip)
+
+add_executable(pennant ${PENNANT_CXX_SRCS} ${PENNANT_HIP_SRCS} )
+
+# Make example runnable using ctest
+add_test(NAME Pennant COMMAND pennant ../test/sedovbig/sedovbig.pnt )
+set_property(TEST Pennant 
+             PROPERTY PASS_REGULAR_EXPRESSION "End cycle   3800, time = 9.64621e-01")
+
+set(ROCMCC_FLAGS "${ROCMCC_FLAGS} -munsafe-fp-atomics")
+set(CUDACC_FLAGS "${CUDACC_FLAGS} ")
+
+if (${GPU_RUNTIME} MATCHES "HIP")
+   set(HIPCC_FLAGS "${ROCMCC_FLAGS}")
+else (${GPU_RUNTIME} MATCHES "HIP")
+   set(HIPCC_FLAGS "${CUDACC_FLAGS}")
+endif (${GPU_RUNTIME} MATCHES "HIP")
+
+set_source_files_properties(${PENNANT_HIP_SRCS} PROPERTIES LANGUAGE ${GPU_RUNTIME})
+set_source_files_properties(HydroGPU.hip PROPERTIES COMPILE_FLAGS ${HIPCC_FLAGS})
+
+install(TARGETS pennant)
+```
+
+To test the cmake build system, do the following
+
+```bash
+mkdir build && cd build
+cmake ..
+make VERBOSE=1
+ctest
+```
+Now testing for CUDA
+
+
+```bash
+module load cuda
+
+mkdir build && cd build
+cmake -DCMAKE_GPU_RUNTIME=CUDA ..
+make VERBOSE=1
+ctest
+```

--- a/HIPStdPar/CXX/README.md
+++ b/HIPStdPar/CXX/README.md
@@ -1,0 +1,138 @@
+# C++ Standard Parallelism on AMD GPUs
+
+Here are some instructions on how to compile and run some tests that exploit C++ standard parallelism.
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo. 
+
+```
+git clone https://github.com/amd/HPCTrainingExamples.git
+```
+
+## hipstdpar_saxpy_foreach example
+
+```
+export HSA_XNACK=1
+module load amdclang
+
+cd ~/HPCTrainingExamples/HIPStdPar/CXX/saxpy_foreach
+
+make
+export AMD_LOG_LEVEL=3
+./saxpy
+clean
+```
+
+## hipstdpar_saxpy_transform example
+
+```
+export HSA_XNACK=1
+module load amdclang
+
+cd ~/HPCTrainingExamples/HIPStdPar/CXX/saxpy_transform
+
+make
+export AMD_LOG_LEVEL=3
+./saxpy
+clean
+```
+
+## hipstdpar_saxpy_transform_reduce example
+
+```
+export HSA_XNACK=1
+module load amdclang
+
+cd ~/HPCTrainingExamples/HIPStdPar/CXX/saxpy_transform_reduce
+
+make
+export AMD_LOG_LEVEL=3
+./saxpy
+clean
+```
+
+## Traveling Salesperson Problem
+
+```
+#!/bin/bash
+
+git clone https://github.com/pkestene/tsp
+cd tsp
+git checkout 51587
+wget -q https://raw.githubusercontent.com/ROCm/roc-stdpar/main/data/patches/tsp/TSP.patch
+
+patch -p1 < TSP.patch
+
+cd stdpar
+
+export HSA_XNACK=1
+module load amdclang
+export STDPAR_CXX=$CXX
+export ROCM_GPU=`rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'`
+export STDPAR_TARGET=${ROCM_GPU}
+
+export AMD_LOG_LEVEL=3 #optional
+
+make tsp_clang_stdpar_gpu
+./tsp_clang_stdpar_gpu 13 #or more...
+
+make clean
+cd ../..
+rm -rf tsp
+```
+
+## hipstdpar_shallowwater_orig.sh
+
+```
+cd ~/HPCTrainingExamples/HIPStdPar/CXX/ShallowWater_Orig
+
+mkdir build && cd build
+cmake ..
+make
+./ShallowWater
+
+cd ..
+rm -rf build
+```
+
+## hipstdpar_shallowwater_ver1.sh
+
+```
+cd ~/HPCTrainingExamples/HIPStdPar/CXX/ShallowWater_Ver1
+
+mkdir build && cd build
+cmake ..
+make
+./ShallowWater
+
+cd ..
+rm -rf build
+```
+
+## hipstdpar_shallowwater_ver2.sh
+
+```
+export HSA_XNACK=1
+module load amdclang
+
+cd ~/HPCTrainingExamples/HIPStdPar/CXX/ShallowWater_Ver2
+
+make
+#export AMD_LOG_LEVEL=3
+./ShallowWater
+
+make clean
+```
+## hipstdpar_shallowwater_stdpar.sh
+
+```
+export HSA_XNACK=1
+module load amdclang
+
+cd ~/HPCTrainingExamples/HIPStdPar/CXX/ShallowWater_StdPar
+
+make
+#export AMD_LOG_LEVEL=3
+./ShallowWater
+
+make clean
+```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,5 @@
-MIT License
-
-Copyright (c) 2022-2024 AMD HPC Application Performance Team
+**Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved**
+This software is distributed under the **MIT License**
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ManagedMemory/README.md
+++ b/ManagedMemory/README.md
@@ -1,7 +1,3 @@
-
---------------------------------------------------------------
-\pagebreak{}
-
 # Programming Model Exercises -- Managed Memory and Single Address Space (APU)
 
 **NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.

--- a/ManagedMemory/README.md
+++ b/ManagedMemory/README.md
@@ -1,0 +1,221 @@
+
+--------------------------------------------------------------
+\pagebreak{}
+
+# Programming Model Exercises -- Managed Memory and Single Address Space (APU)
+
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
+
+The source code for these exercises is based on those in the presentation, but with details
+filled in so that there is a working code. You may want to examine the code in these exercises
+and compare it to the code in the presentation and to the code in the other exercises.
+
+## CPU Code baseline
+
+```
+git clone https://github.com/amd/HPCTrainingExamples.git
+cd HPCTrainingExamples/ManagedMemory
+```
+First run the standard CPU code. This is a working version of the original CPU code from the programming model presentation.
+
+```
+cd HPCTrainingExamples/ManagedMemory/CPU_Code
+module load amdclang
+make
+```
+
+will compile with `amdclang -g -O3 -fopenmp cpu_code.c -o cpu_code`
+Then run code with
+
+```
+./cpu_code
+```
+
+## Standard GPU Code example
+
+This example adds the GPU memory corresponding to the CPU arrays and explicitly manages the memory transfers. 
+
+```
+cd ../GPU_Code
+make
+```
+
+This will compile with `hipcc -g -O3 -fopenmp --offload-arch=gfx90a gpu_code.hip -o gpu_code`
+Then run the code with
+
+```
+./gpu_code
+```
+
+## Managed Memory Code
+
+In this example, we will set the `HSA_XNACK` environment variable to 1 and let the Operating System move the memory for us.
+
+```
+export HSA_XNACK=1
+cd ../Managed_Memory_Code
+make
+./gpu_code
+```
+
+## APU Code -- Single Address Space in HIP
+
+This example is shown on slide 29. We'll run the same code as we used in the managed memory 
+example. Because 
+the memory pointers are addressable on both the CPU and the GPU, no memory managment is necessary. First, 
+log onto an MI300A node. Then compile and run the code as follows.
+
+```
+cd ../APU_Code
+make
+./gpu_code
+```
+
+## OpenMP APU or single address space
+
+For this example, we have a simple code with the loop offloading in the main code, `openmp_code`, and a second version, `openmp_code1`, with the offloaded loop in a subroutine where the compiler cannot tell the size of the array. Running this on the MI200 series, it passes, despite that it does not have a single address space. We add `export LIBOMPTARGET_INFO=-1` to verify that it is running on the GPU. 
+
+```
+export HSA_XNACK=1
+module load amdclang
+cd ../OpenMP_Code
+make
+./openmp_code
+./openmp_code1
+export LIBOMPTARGET_INFO=-1
+./openmp_code
+./openmp_code1
+```
+
+For more experimentation with this example, comment out the first line of the two source codes.
+
+```
+//#pragma omp requires unified_shared_memory
+make
+export LIBOMPTARGET_INFO=-1
+./openmp_code
+./openmp_code1
+```
+
+Now with the `LIBOMPTARGET_INFO` variable set, we get a report that memory is being copied to the device
+and back. The OpenMP compiler is helping out a lot more than might be expected even without an APU.
+
+## RAJA Single Address Code
+
+First, set up the environment
+
+```
+module load amdclang
+module load rocm
+```
+
+For the Raja example, we need to build the Raja code first
+
+```
+cd ~/HPCTrainingExamples/ManagedMemory/Raja_Code
+
+PWDir=`pwd`
+
+git clone --recursive https://github.com/LLNL/RAJA.git Raja_build
+cd Raja_build
+
+mkdir build_hip && cd build_hip
+
+cmake -DCMAKE_INSTALL_PREFIX=${PWDir}/Raja_HIP \
+      -DROCM_ROOT_DIR=/opt/rocm \
+      -DHIP_ROOT_DIR=/opt/rocm \
+      -DHIP_PATH=/opt/rocm/bin \
+      -DENABLE_TESTS=Off \
+      -DENABLE_EXAMPLES=Off \
+      -DRAJA_ENABLE_EXERCISES=Off \
+      -DENABLE_HIP=On \
+      ..
+
+make -j 8
+make install
+
+cd ../..
+
+rm -rf Raja_build
+
+export Raja_DIR=${PWDir}/Raja_HIP
+```
+
+Now we build the example. Note that we just allocated the arrays on the
+host with malloc. To run it on the MI200 series, we need to set the
+`HSA_XNACK` variable.
+
+```
+# To run with managed memory
+export HSA_XNACK=1
+
+mkdir build && cd build
+CXX=hipcc cmake ..
+make
+./raja_code
+
+cd ..
+rm -rf build
+
+cd ${PWDir}
+rm -rf Raja_HIP
+
+cd ..
+rm -rf ${PROB_NAME}
+```
+
+## Kokkos Unified Address Code
+
+First, set up the environment
+
+```
+module load amdclang
+module load rocm
+```
+
+For the Kokkos example, we need to build the Kokkos code first
+
+```
+cd ~/HPCTrainingExamples/ManagedMemory/Kokkos_Code
+
+PWDir=`pwd`
+
+git clone https://github.com/kokkos/kokkos Kokkos_build
+cd Kokkos_build
+
+mkdir build_hip && cd build_hip
+cmake -DCMAKE_INSTALL_PREFIX=${PWDir}/Kokkos_HIP -DKokkos_ENABLE_SERIAL=ON \
+      -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_ZEN=ON -DKokkos_ARCH_VEGA90A=ON \
+      -DCMAKE_CXX_COMPILER=hipcc ..
+
+make -j 8
+make install
+
+cd ../..
+
+rm -rf Kokkos_build
+
+export Kokkos_DIR=${PWDir}/Kokkos_HIP
+```
+
+Now we build the example. Note that we have not had to declare the arrays
+in Kokkos Views. To run it on the MI200 series, we need to set the
+`HSA_XNACK` variable.
+
+```
+# To run with managed memory
+export HSA_XNACK=1
+
+mkdir build && cd build
+CXX=hipcc cmake ..
+make
+./kokkos_code
+
+cd ${PWDir}
+rm -rf Kokkos_HIP
+
+cd ..
+rm -rf ${PROB_NAME}
+```
+

--- a/Pragma_Examples/README.md
+++ b/Pragma_Examples/README.md
@@ -1,26 +1,515 @@
-These examples are for use in AMD training and testing. They are released under the MIT license as
-described in the License.txt file in the main directory of the Examples. Any copies or use of these
-examples shall include the license and copyright notice.
 
-These examples are tested on the Thera system, an internal AMD testing 
-system. Modules and environment files are for that system. They give
-an idea of what environment should be set up for other systems.
+                    %------------------------%
 
-To run on Thera. Will run all four compilers with both OpenMP
-and OpenACC and report whether the compilation is successful.
-   ./runall.sh
+\pagebreak{}
 
-Example code
-A simple vector add example
+# OpenMP Intro Examples
 
-The compilers can be specified with the CC and FC variables. 
-The rocminfo should be in the path (${ROCM_PATH}/bin) or
-the GPU model can be specified in the ROCM_GPU environment variable.
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
 
-To set up environment on Thera, source the *_env file
+## Checking out makefiles and compiler toolchain
 
-To compile and run in separate steps, first set up your environment
-and then:
+Running the first OpenMP example: `Pragma_Examples/OpenMP/C/Make/saxpy`
 
+### Build with AMDClang compiler
+
+```bash
+module load amdclang
+make clean 
+make 
+./saxpy 
+```
+
+Confirm running on GPU with  
+
+```bash
+export LIBOMPTARGET_KERNEL_TRACE=1 
+./saxpy
+```
+
+   * confirms that we are running on the GPU and also gives us the register usage 
+   * Also could use `AMD_LOG_LEVEL=[0|1|2|3|4]` or `LIBOMPTARGET_KERNEL_TRACE=2`
+
+
+## OpenMP Offload -- The Basics
+
+We start out with the OpenMP threaded code for the CPU. This code is in 
+`~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro` in the saxpy_cpu.cpp file. This
+is the code on slide 16. We first load the amdclang module which will set the CXX
+environment variable. This variable will get picked up by the Makefile for the build.
+
+```
+module load amdclang
+make saxpy_cpu
+./saxpy_cpu
+```
+
+The next example, saxpy1, is from slide 18 where the first version of OpenMP offloading is
+tried. In this code, there is no map clause. The compiler can figure out the arrays that need to be copied 
+over and their sizes.
+
+```
+make saxpy1
+./saxpy1
+```
+While running one of these codelets, it may be useful to watch the GPU usage. Here are two approaches.
+
+- open another terminal and `ssh` to the AAC node you are working on, or 
+- use the tmux command
+  
+- run `watch -n 0.5 rocm-smi` command line from that terminal to visualize GPU activities.
+
+Note that the basic tmux survival commands are:
+```
+cntl+b \"  - splits the screen  
+cntl+b (up arrow) - move to the upper session
+cntl+b (down arrow) - move to lower session
+exit - end tmux session
+```
+
+Next, run the codelet on your preferred GPU device if you have allocated more than 1 GPU. For example, to execute on GPU ID #2, set the following environment variable: `export ROCR_VISIBLE_DEVICES=2` then run the code.
+
+Profile the codelet and then compare output by setting
+```bash
+export LIBOMPTARGET_KERNEL_TRACE=1
+export LIBOMPTARGET_KERNEL_TRACE=2
+```
+Note:
+
+rocminfo can be used to get target architecture information.
+
+
+The Fortran version of the saxpy code is shown in saxpy1f.F90. It is very similar to the
+C and C++ OpenMP pragmas. In Fortran, the compiler hints are technically directives that
+are contained in specially formatted comments. One of the strengths of OpenMP is that 
+the language can be used in C, C++, and Fortran code and they can even be mixed in an
+application. Here is how to run the Fortran example.
+
+```
+make saxpy1f
+./saxpy1f
+```
+
+The compile line uses the specific GPU architecture type. It grabs it from the rocminfo
+command with a little bit of string manipulation. 
+
+Let's now add a map clause as shown in quotes on slide 18 -- map(tofrom:y[0:N])
+
+```
+make saxpy2
+./saxpy2
+```
+
+A lot of the initial optimization of an OpenMP offloading port is to minimize the
+data movement from host to device and back. What is the optimum mapping of data
+for this example? See saxpy3.cpp for the optimal map clauses.
+
+```
+make saxpy3
+./saxpy3
+```
+
+In the example we have been working with so far, the compiler can determine the sizes
+and will move the data for you. Let's see what happens when we have a subroutine
+with pointers where the compiler does not know the sizes.
+
+```
+make saxpy4
+./saxpy4
+```
+
+Try removing the map clause -- the program will now fail.
+
+## Multilevel Parallelism
+
+We have been running on the GPU, but with only one thread in serial. Let's start adding parallelism.
+The first thing we can do is add `#pragma omp parallel for simd` before the loop to tell it to run in parallel.
+
+```
+make saxpy5
+./saxpy5
+```
+
+We have told it to run the loop in parallel, but we haven't given it any hardware resources. To add more
+compute units, we need to add the teams clause. Then to spread the work across the threads, we need the 
+distribute clause. (This code is currently not working ...)
+
+```
+make saxpy6
+./saxpy6
+```
+
+More commonly, we add the triplet of `target teams distribute` to the pragma to enable all hardware
+elements to the computation.
+
+```
+make saxpy7
+./saxpy7
+```
+
+And in Fortran.
+
+```
+make saxpy2f
+./saxpy2f
+```
+
+## Structured and Unstructured Target Data Regions
+
+This example from slide 29 shows the use of a structured block region that encompasses several
+compute loops. The data region persists across all of them, eliminating the need for map
+clauses and data transfers.
+
+```
+make target_data_structured
+./target_data_structured
+```
+
+This example shows the use of the target data to map the data to the device and then updating
+it with the target update in the middle of the target data block.
+
+```
+make target_data_unstructured
+./target_data_unstructured
+```
+
+When using larger data regions, it can be necessary to move data in the middle of the region
+to support MPI communication or I/O. This example shows the use of the update clause to copy
+new input from the host to the device.
+
+```
+make target_data_update
+./target_data_update
+```
+
+\pagebreak{}
+
+# Advanced OpenMP Presentation
+
+Here, we will discuss some examples that show more advanced OpenMP features.
+
+## Memory Pragmas
+First, we will consider the examples in the `CXX/memory_pragmas` directory:
+
+```bash
+cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/CXX/memory_pragmas
+```
+
+### Exercises Setup
+
+Setup your environment:
+
+```bash
+export LIBOMPTARGET_INFO=-1
+export OMP_TARGET_OFFLOAD=MANDATORY
+```
+The first flag above will allow you to see OpenMP activity, while the second terminates the program if code fails to be executed on device (as opposed to falling back on the host). You can also be more selective in the output generated by using the individual bit masks:
+
+```bash
+export LIBOMPTARGET_INFO=$((0x01 | 0x02 | 0x04 | 0x08 | 0x10 | 0x20))
+```
+
+Create a build directory and compile using `cmake`: this will place all executables in the `build` directory:
+
+```bash
+mkdir build && cd build
+cmake ..
+make 
+```
+### Mem1 (Initial Version)
+
+There are 12 versions of an initial example code called `mem1.cc`, which is an implementation of a `daxpy` kernel with a single pragma with a map clause at the computational loop:
+
+```bash
+void daxpy(int n, double a, double *__restrict__ x, double *__restrict__ y, double *__restrict__ z)
+{
+#pragma omp target teams distribute parallel for simd map(to: x[0:n], y[0:n]) map(from: z[0:n])
+        for (int i = 0; i < n; i++)
+                z[i] = a*x[i] + y[i];
+}
+
+```
+Run `mem1` to have an idea of what output is produced by the `LIBOMPTARGET_INFO=-1` flag, which should include OpenMP calls like the following:
+
+```bash
+Libomptarget device 0 info: Entering OpenMP kernel at mem1.cc:89:1 with 5 arguments:
+Libomptarget device 0 info: firstprivate(n)[4] (implicit)
+Libomptarget device 0 info: from(z[0:n])[80000]
+Libomptarget device 0 info: firstprivate(a)[8] (implicit)
+Libomptarget device 0 info: to(x[0:n])[80000]
+Libomptarget device 0 info: to(y[0:n])[80000]
+Libomptarget device 0 info: Creating new map entry with HstPtrBase=0x0000000001772200, ... 
+Libomptarget device 0 info: Creating new map entry with HstPtrBase=0x000000000174b0e0, ... 
+Libomptarget device 0 info: Copying data from host to device, HstPtr=0x000000000174b0e0, ...
+Libomptarget device 0 info: Creating new map entry with HstPtrBase=0x000000000175e970, ...
+Libomptarget device 0 info: Copying data from host to device, HstPtr=0x000000000175e970, ...
+Libomptarget device 0 info: Mapping exists with HstPtrBegin=0x0000000001772200, ...
+Libomptarget device 0 info: Mapping exists with HstPtrBegin=0x000000000174b0e0, ...
+Libomptarget device 0 info: Mapping exists with HstPtrBegin=0x000000000175e970, ...
+Libomptarget device 0 info: Mapping exists with HstPtrBegin=0x000000000175e970, ...
+Libomptarget device 0 info: Mapping exists with HstPtrBegin=0x000000000174b0e0, ...
+Libomptarget device 0 info: Mapping exists with HstPtrBegin=0x0000000001772200, ...
+Libomptarget device 0 info: Copying data from device to host, TgtPtr=0x00007f617c420000, ...
+Libomptarget device 0 info: Removing map entry with HstPtrBegin=0x000000000175e970, ...
+Libomptarget device 0 info: Removing map entry with HstPtrBegin=0x000000000174b0e0, ...
+Libomptarget device 0 info: Removing map entry with HstPtrBegin=0x0000000001772200, ...
+-Timing in Seconds: min=0.010115, max=0.010115, avg=0.010115
+-Overall time is 0.010505
+Last Value: z[9999]=7.000000
+```
+
+Not all versions are discussed in this document. Using `vimdiff` to compare versions is useful to explore the differences, e.g.:
+
+```bash
+vimdiff mem1.cc mem2.cc
+```
+
+### Mem2 (Add enter/exit data alloc/delete when memory is created/freed)
+
+The initial code in `mem1.cc` is modified to obtain `mem2.cc` with the following additions:
+
+```bash
+#pragma omp target enter data map(alloc: x[0:n], y[0:n], z[0:n]) // line 52
+```
+
+```bash
+#pragma omp target exit data map(delete: x[0:n], y[0:n], z[0:n]) // line 82
+```
+
+
+### Mem3 (Replace map to/from with updates to bypass unneeded device memory check)
+
+In `mem3.cc`, in addition to the changes in `mem2.cc`,  the `daxpy` kernel is modified as follows:
+
+```bash
+void daxpy(int n, double a, double *__restrict__ x, double *__restrict__ y, double *__restrict__ z)
+{
+#pragma omp target update to (x[0:n], y[0:n])
+#pragma omp target teams distribute parallel for simd
+        for (int i = 0; i < n; i++)
+                z[i] = a*x[i] + y[i];
+#pragma omp target update from (z[0:n])
+}
+```
+
+### Mem4 (Replace delete with release to use reference counting)
+
+Compared to `mem2.cc`, `mem4.cc` differs only at line 82, where a delete is replaced with a release:
+
+```bash
+#pragma omp target exit data map(release: x[0:n], y[0:n], z[0:n]) // line 82
+```
+
+### Mem5 (Use enter data map to/from alloc/delete to reduce memory copies)
+
+Similar to `mem2.cc`. this version differs from the original only at lines 52 and 82:
+
+```bash
+#pragma omp target enter data map(to: x[0:n], y[0:n]) map(alloc: z[0:n]) // line 52
+```
+
+```bash
+#pragma omp target exit data map(from: z[0:n]) map(delete: x[0:n], y[0:n]) // line 82
+```
+### Mem7 (Use managed memory to automatically move data)
+
+In this example, we epxloit automatic memory management by the operating system. To enable it, export:
+
+```bash
+export HSA_XNACK=1
+```
+We also need to include the following pragma:
+
+```bash
+#pragma omp requires unified_shared_memory // line 22
+```
+
+### Mem8 (Use unified shared memory with maps for backward compatibility)
+
+Compared to `mem7.cc`, `mem8.cc` supports backward compatibility using maps and also:
+
+```bash
+#ifndef NO_UNIFIED_SHARED_MEMORY
+#pragma omp requires unified_shared_memory
+#endif
+```
+### Mem12 (Only runs on MI300A)
+
+This example uses the APU programming model of MI300A and  unified addresses in OpenMP.
+
+## Kernel Pragmas
+
+This set of exercises is in: `HPCTrainingExamples/Pragma_Examples/OpenMP/CXX/kernel_pragmas`.
+
+### Exercises Setup
+
+You should unset the `LIBOMPTARGET_INFO` environment flag if previously set.
+
+```bash
+unset LIBOMPTARGET_INFO
+```
+
+Then, set these environment variable
+
+```bash
+export CXX=amdclang++
+export LIBOMPTARGET_KERNEL_TRACE=1
+export OMP_TARGET_OFFLOAD=MANDATORY
+export HSA_XNACK=1
+```
+
+### Brief Exercises Description
+
+The example `kernel1.cc` is the same as `memory_pragmas/mem11.cc` except for the pragma line below (from `kernel1.cc`):
+
+```bash
+cout << "-Overall time is " << main_timer << endl;
+#pragma omp target update from(z[0])
+```
+
+The example `kernel2.cc` differs from `kernel1.cc` as it adds `num_threads(64)` to the pragma line in the `daxpy` kernel:
+
+```bash
+void daxpy(int n, double a, double *__restrict__ x, double *__restrict__ y, double *__restrict__ z)
+{
+#pragma omp target teams distribute parallel for simd num_threads(64)
+        for (int i = 0; i < n; i++)
+                z[i] = a*x[i] + y[i];
+}
+```
+
+Similarly,  example `kernel3.cc` differs from `kernel1.cc` as it adds `num_threads(64) thread_limit(64)` to the pragma line in the `daxpy` kernel:
+
+```bash
+void daxpy(int n, double a, double *__restrict__ x, double *__restrict__ y, double *__restrict__ z)
+{
+#pragma omp target teams distribute parallel for simd num_threads(64) thread_limit(64)
+        for (int i = 0; i < n; i++)
+                z[i] = a*x[i] + y[i];
+}
+```
+Something to test On your own: uncomment line 15 in CMakeLists.txt (the one with -faligned-allocation -fnew-alignment=256).
+
+Another option to explore is adding the attribute (std::align_val_t(128) ) to each new line, for example:
+
+```bash
+double *x = new (std::align_val_t(128) ) double[n];
+```
+\pagebreak{}
+
+# Real-World OpenMP Language Constructs
+
+For all excercises in this section:
+```bash
+module load amdclang
+git clone https://github.com/AMD/HPCTrainingExamples
+```
+either choose
+```bash
+cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+```
+or 
+```bash
+cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C
+```
+
+***Note***: make sure the compilers are set to your preference. This can be obtained  by exporting the `FC` and `CC` environment variables:
+
+```
+export FC=<my favorite Fortran compiler>
+export CC=<my favorite C compiler>
+```
+It is suggested for those that want to truly experience the effort, that you take all the 
+pragma statements out of these examples and do the port yourself.
+
+## Simple Reduction
+
+The first example is a simple reduction:
+```bash
+cd reduction_scalar
 make
-./vecadd
+./reduction_scalar
+```
+Now try the array form
+```bash
+cd ../reduction_array
+make
+./reduction_array
+```
+
+If your compiler passes, it supports at least simple array reduction clauses
+
+## Device Routine
+
+Subroutines called from within a target region also cause some difficulties. We must tell the compiler that we want
+these compiled for the GPU. Note that device routines are not (yet) supported by all compilers!
+
+For this example
+
+```bash
+cd ../device_routine
+```
+there are multiple versions to choose from in Fortran, either with an interface and an external routine or using a module
+
+```bash
+make
+./device_routine
+```
+
+## Device Routine with Global Data
+
+Including the use of data from global scope in device routines also causes difficulties. We have examples for
+both statically sized arrays and dynamically allocated global data. 
+Note that device routines are not (yet) supported by all compilers!
+Also, this excercise only exists in the C version at the moment.
+
+<!-- Johanna: I maybe will do a Fortran version and hopefully remember to update here... -->
+
+```bash
+cd ../device_routine_wglobaldata
+make
+./device_routine
+```
+
+```bash
+cd ../device_routine_wdynglobaldata
+make
+./device_routine
+```
+
+
+
+# HIP and OpenMP Interoperability
+
+This hands-on exercise uses the code in HPCTrainingExamples/HIP-OpenMP/daxpy. We have code that uses both OpenMP and HIP. These require two separate passes with compilers: one with amdclang++ and the other with hipcc. Go to the directory containing the example and set up the environment:
+
+```
+cd HPCTrainingExamples/HIP-OpenMP/CXX/daxpy
+module load rocm
+export CXX=amdclang++
+```
+View the source code file daxpy.cc and note the two #ifdef blocks.
+
+ The first one is __DEVICE_CODE__ that we want to compile with hipcc.
+
+ The second is __HOST_CODE__ that we will use the C++ compiler to compile.
+
+ All of the HIP calls and variables are in the first block. The second block contains the OpenMP pragmas.
+
+ While we can use hipcc to compile standard C++ code, it will not work on code with OpenMP pragmas. The call to the HIP daxpy kernel occurs near the end of the host code block. We could split out these two code blocks into separate files, but this may be more intrusive with a code design.
+
+Now we can take a look at the Makefile we use to compile the code in the single file. In the file, we create two object files for the executable to be dependent on. 
+
+ We then compile one with the CXX compiler with `-D__HOST_CODE__` defined.
+
+ The second object file is compiled using hipcc and with `-D__DEVICE_CODE__` defined.
+
+ This doesn't completely solve all the issues with separate translation units, but it does help workaround some code organization constraints.
+
+Now on to building and running the example.
+
+```
+make
+./daxpy
+```

--- a/Pragma_Examples/README.md
+++ b/Pragma_Examples/README.md
@@ -1,8 +1,3 @@
-
-                    %------------------------%
-
-\pagebreak{}
-
 # OpenMP Intro Examples
 
 **NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
@@ -182,8 +177,6 @@ new input from the host to the device.
 make target_data_update
 ./target_data_update
 ```
-
-\pagebreak{}
 
 # Advanced OpenMP Presentation
 
@@ -396,7 +389,6 @@ Another option to explore is adding the attribute (std::align_val_t(128) ) to ea
 ```bash
 double *x = new (std::align_val_t(128) ) double[n];
 ```
-\pagebreak{}
 
 # Real-World OpenMP Language Constructs
 

--- a/Pragma_Examples/README_Thera.md
+++ b/Pragma_Examples/README_Thera.md
@@ -1,0 +1,26 @@
+These examples are for use in AMD training and testing. They are released under the MIT license as
+described in the License.txt file in the main directory of the Examples. Any copies or use of these
+examples shall include the license and copyright notice.
+
+These examples are tested on the Thera system, an internal AMD testing 
+system. Modules and environment files are for that system. They give
+an idea of what environment should be set up for other systems.
+
+To run on Thera. Will run all four compilers with both OpenMP
+and OpenACC and report whether the compilation is successful.
+   ./runall.sh
+
+Example code
+A simple vector add example
+
+The compilers can be specified with the CC and FC variables. 
+The rocminfo should be in the path (${ROCM_PATH}/bin) or
+the GPU model can be specified in the ROCM_GPU environment variable.
+
+To set up environment on Thera, source the *_env file
+
+To compile and run in separate steps, first set up your environment
+and then:
+
+make
+./vecadd

--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
-These examples are for use in AMD training and testing. They are released under the MIT license as
-described in the LICENSE file in the main directory of the Examples. Any copies or use of these
-examples shall include the license and copyright notice. 
+##AMD HPC Training Examples Repo
 
-Version 0.8
+Welcome to AMD's HPC Training Examples Repo!
+Here you will find a variety of examples to showcase the capabilities of AMD's GPU software stack.
+Please be aware that the repo is continuously updated to keep up with the most recent releases of the AMD software.
+
+### Run the Tests
+
+Most of the exercises in this repo can be run as a test suite by doing:
+
+```
+git clone https://github.com/amd/HPCTrainingExamples && \
+cd HPCTrainingExamples && \
+export REPO_DIR = $PWD && \
+cd tests && \
+./runTests.sh
+```
+
+### Feedback
+We welcome your feedback and contributions, feel free to use this repo to bring up any issues or submit pull requests.
+The software made available here is released under the MIT license, more details can be found in `LICENSE.md`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##AMD HPC Training Examples Repo
+## AMD HPC Training Examples Repo
 
 Welcome to AMD's HPC Training Examples Repo!
 Here you will find a variety of examples to showcase the capabilities of AMD's GPU software stack.

--- a/README_DIR/gpu_aware_mpi.md
+++ b/README_DIR/gpu_aware_mpi.md
@@ -1,0 +1,171 @@
+
+--------------------------------------------------------------
+\pagebreak{}
+
+# GPU Aware MPI
+## Point-to-point and collective
+
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
+
+Allocate at least two GPUs and set up your environment
+
+```
+module load openmpi rocm
+export OMPI_CXX=hipcc
+```
+
+Find the code and compile
+```
+cd HPCTrainingExamples/MPI-examples
+mpicxx -o ./pt2pt ./pt2pt.cpp
+```
+Set the environment variable and run the code
+```
+mpirun -n 2 -mca pml ucx ./pt2pt
+```
+
+## OSU Benchmark
+
+Get the OSU micro-benchmark tarball and extract it
+```
+mkdir OMB
+cd OMB
+wget https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-7.3.tar.gz
+tar -xvf osu-micro-benchmarks-7.3.tar.gz
+```
+
+Create a build directory and cd to osu-micro-benchmarks-7.3
+```
+mkdir build
+cd osu-micro-benchmarks-7.3
+module load rocm openmpi
+```
+
+Build and install OSU micro-benchmarks
+```
+./configure --prefix=`pwd`/../build/ \
+                CC=`which mpicc` \
+                CXX=`which mpicxx` \
+                --enable-rocm \
+                --with-rocm=${ROCM_PATH}
+make -j12
+make install
+```
+If you get the error "cannot include hip/hip_runtime_api.h", grep for __HIP_PLATFORM_HCC__ and replace it with __HIP_PLATFORM_AMD__ in configure.ac and configure files.
+
+Check if osu microbenchmark is actually built
+```
+ls -l ../build/libexec/osu-micro-benchmarks/mpi/
+
+```
+if you see files collective, one-sided, pt2pt, and startup, your build is successful.
+
+Allocate 2 GPUs, and make those visible
+```
+export HIP_VISIBLE_DEVICES=0,1
+```
+
+Make sure GPU-Aware communication is enabled and run the benchmark
+```
+mpirun -n 2 -mca pml ucx ../build/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bw \
+				-m $((16*1024*1024)) D D
+```
+
+
+Notes:
+- Try different pairs of GPUs.
+- Run the command "rocm-smi --showtopo" to see the link type between the pairs of GPUs. 
+- How does the bandwidth vary for xGMI connected GPUs vs PCIE connected GPUs?
+
+## Ghost Exchange example
+
+This example takes an MPI Ghost Exchange code that runs on the CPU and ports it to
+the GPU and GPU-aware MPI. 
+
+```
+module load amdclang openmpi
+git clone https://github.com/amd/HPCTrainingExamples.git
+cd HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign/Orig
+mkdir build && cd build
+cmake ..
+make
+mpirun -n 8 --mca pml ucx ./GhostExchange -x 4  -y 2  -i 20000 -j 20000 -h 2 -t -c -I 1000
+```
+We can improve this performance by using process placement so that we are using all the memory
+channels.
+
+On MI2100 nodes, we have 2 NUMA per node. So we can assign 4 ranks per NUMA when running with 8 ranks:
+
+```
+mpirun -n 8 --mca pml ucx --bind-to core --map-by ppr:4:numa --report-bindings ./GhostExchange \
+				    -x 4  -y 2  -i 20000 -j 20000 -h 2 -t -c -I 1000
+```
+
+On MI300A node, we have 4 NUMA per node. So we can assign 2 ranks per NUMA when running with 8 ranks:
+
+```
+mpirun -n 8 --mca pml ucx --bind-to core --map-by ppr:2:numa --report-bindings ./GhostExchange \
+				    -x 4  -y 2  -i 20000 -j 20000 -h 2 -t -c -I 1000
+```
+
+For the port to the GPU, we are going to take advantage of Managed Memory (or single memory space on MI300A)
+
+```
+export HSA_XNACK=1
+cd ../Ver1
+mkdir build && cd build
+cmake ..
+make
+mpirun -n 8 --mca pml ucx --bind-to core --map-by ppr:4:numa -x HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \ 
+					./GhostExchange -x 4  -y 2  -i 20000 -j 20000 -h 2 -t -c -I 1000
+```
+
+Alternatively, on MI300A, we can run with:
+
+```
+mpirun -n 8 --mca pml ucx --bind-to core --map-by ppr:2:numa -x HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+				    ./GhostExchange -x 4  -y 2  -i 20000 -j 20000 -h 2 -t -c -I 1000
+```
+
+The MPI buffers are only used on the GPU, so we can just allocate them there and save memory on the CPU.
+
+```
+export HSA_XNACK=1
+cd ../Ver3
+mkdir build && cd build
+cmake ..
+make
+mpirun -n 8 --mca pml ucx --bind-to core --map-by ppr:4:numa -x HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \ 
+					./GhostExchange -x 4  -y 2  -i 20000 -j 20000 -h 2 -t -c -I 1000
+```
+
+Alternatively, on MI300A, we can run with:
+
+```
+mpirun -n 8 --mca pml ucx --bind-to core --map-by ppr:2:numa -x HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+				    ./GhostExchange -x 4  -y 2  -i 20000 -j 20000 -h 2 -t -c -I 1000
+```
+
+Memory allocations can be expensive for the GPU. This next version just allocates the MPI buffers once
+in the main routine.
+
+```
+export HSA_XNACK=1
+cd ../Ver3
+mkdir build && cd build
+cmake ..
+make
+mpirun -n 8 --mca pml ucx --bind-to core --map-by ppr:4:numa -x HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+					./GhostExchange -x 4  -y 2  -i 20000 -j 20000 -h 2 -t -c -I 1000cd
+```
+
+Alternatively, on MI300A, we can run with:
+
+```
+mpirun -n 8 --mca pml ucx --bind-to core --map-by ppr:2:numa -x HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+				   ./GhostExchange -x 4  -y 2  -i 20000 -j 20000 -h 2 -t -c -I 1000
+```
+
+
+

--- a/README_DIR/gpu_aware_mpi.md
+++ b/README_DIR/gpu_aware_mpi.md
@@ -1,7 +1,3 @@
-
---------------------------------------------------------------
-\pagebreak{}
-
 # GPU Aware MPI
 ## Point-to-point and collective
 

--- a/README_DIR/kokkos.md
+++ b/README_DIR/kokkos.md
@@ -1,0 +1,199 @@
+--------------------------------------------------------------
+
+\pagebreak{}
+
+
+# Kokkos examples
+
+## Stream Triad
+
+### Step 1: Build a separate Kokkos package
+```
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
+
+
+cd $HOME/HPCTraining/Examples
+git clone https://github.com/kokkos/kokkos Kokkos_build
+cd Kokkos_build
+```
+
+Build Kokkos with OpenMP backend
+
+```
+mkdir build_openmp && cd build_openmp
+cmake -DCMAKE_INSTALL_PREFIX=${HOME}/Kokkos_OpenMP -DKokkos_ENABLE_SERIAL=On \
+      -DKokkos_ENABLE_OPENMP=On ..
+
+make -j 8
+make install
+
+cd ..
+```
+Build Kokkos with HIP backend
+
+```
+mkdir build_hip && cd build_hip
+cmake -DCMAKE_INSTALL_PREFIX=${HOME}/Kokkos_HIP -DKokkos_ENABLE_SERIAL=ON \
+      -DKokkos_ENABLE_HIP=ON -DKokkos_ARCH_ZEN=ON -DKokkos_ARCH_VEGA90A=ON \
+      -DCMAKE_CXX_COMPILER=hipcc ..
+
+make -j 8; make install
+cd ..
+```
+
+Set Kokkos_DIR to point to external Kokkos package to use
+
+```
+export Kokkos_DIR=${HOME}/Kokkos_HIP
+```
+
+### Step 2: Modify Build
+
+Get example
+
+```
+git clone --recursive https://github.com/EssentialsOfParallelComputing/Chapter13 Chapter13
+cd Chapter13/Kokkos/StreamTriad
+cd Orig
+```
+
+Test serial version with 
+
+```
+mkdir build && cd build; cmake ..; make; ./StreamTriad
+```
+
+If the run fails (SEGV), try reducing the size of the arrays, by reducing the value of the nsize variable in StreamTriad.cc.
+
+Add to CMakeLists.txt
+
+```
+(add) find_package(Kokkos REQUIRED)
+add_executables(StreamTriad ....)
+(add) target_link_libraries(StreamTriad Kokkos::kokkos)
+```
+
+Retest with 
+
+```
+cmake ..; make
+```
+and run ./StreamTriad again
+
+Check Ver1 for solution. These modifications have already been made in Ver1 version.
+
+### Step 3: Add Kokkos views for memory allocation of arrays
+
+(peek at ver4/StreamTriad.cc to see the end result)
+
+Add include file
+
+```
+#include <Kokkos_Core.hpp>
+```
+
+Add initialize and finalize
+
+```
+Kokkos::initialize(argc, argv);  {
+
+} Kokkos::finalize();
+```
+
+Replace static array declarations with Kokkos views
+
+```
+int nsize=80000000;
+Kokkos::View<double *> a( "a", nsize);
+Kokkos::View<double *> b( "b", nsize);
+Kokkos::View<double *> c( "c", nsize);
+```
+
+Rebuild and run
+
+```
+CXX=hipcc cmake ..
+make
+./StreamTriad
+```
+
+#### Step 4: Add Kokkos execution pattern - parallel_for
+
+Change for loops to Kokkos parallel fors.
+
+At start of loop
+
+```
+Kokkos::parallel_for(nsize, KOKKOS_LAMBDA (int i) {
+```
+
+  At end of loop, replace closing brace with 
+
+```
+});
+```
+
+Rebuild and run. Add environment variables as Kokkos message suggests:
+
+```
+ export OMP_PROC_BIND=spread
+ export OMP_PLACES=threads
+ export OMP_PROC_BIND=true
+```
+
+How much speedup do you observe?
+
+### Step 5: Add Kokkos timers
+
+Add Kokkos calls
+
+```
+Kokkos::Timer timer;
+timer.reset(); // for timer start
+time_sum += timer.seconds();
+```
+
+Remove
+
+```
+#include <timer.h>
+struct timespec tstart;
+cpu_timer_start(&tstart);
+time_sum += cpu_timer_stop(tstart);
+```
+
+### 6. Run and measure performance with OpenMP
+
+Find out how many virtual cores are on your CPU
+
+```
+lscpu
+```
+
+First run with a single processor:
+
+Average runtime ___________
+
+Then run the OpenMP version:
+
+Average runtime ___________
+
+### Portability Exercises
+
+1. Rebuild Stream Triad using Kokkos build with HIP
+
+Set Kokkos_DIR to point to external Kokkos build with HIP
+
+```
+export Kokkos_DIR=${HOME}/Kokkos_HIP/lib/cmake/Kokkos_HIP
+cmake ..
+make
+```
+
+2. Run and measure performance with AMD Radeon GPUs
+
+HIP build with ROCm
+
+Ver4 - Average runtime is ______ msecs
+

--- a/README_DIR/kokkos.md
+++ b/README_DIR/kokkos.md
@@ -1,18 +1,13 @@
---------------------------------------------------------------
-
-\pagebreak{}
-
-
 # Kokkos examples
 
 ## Stream Triad
 
 ### Step 1: Build a separate Kokkos package
-```
+
 **NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
 To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
 
-
+```bash
 cd $HOME/HPCTraining/Examples
 git clone https://github.com/kokkos/kokkos Kokkos_build
 cd Kokkos_build

--- a/README_DIR/ml_ai.md
+++ b/README_DIR/ml_ai.md
@@ -1,0 +1,435 @@
+
+--------------------------------------------------------------
+\pagebreak{}
+
+# AI and ML exercises
+
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
+
+Throughout these exercises we'll be leveraging the existing ROCm instalation. We can use the existing module to set the environment for it:
+
+```
+module purge
+module load rocm/6.1.0
+``` 
+
+Also, note that these exercises are preapared for MI200 GPU series.
+
+## Setting the virtual environments
+These exercises include use cases for PyTorch and TensorFlow using Horovod. Let's prepare the environments to install these frameworks.
+
+We'll be leveraging the system Python instalation, so we'll be creating virtual environments to add the Python packages we need:
+
+```
+python3 -m venv --system-site-packages $HOME/venv-pt
+python3 -m venv --system-site-packages $HOME/venv-tf
+```
+
+## Installing the frameworks
+Let's install a PytTorch and Tensrflow suitable to the ROCm version we have available: ROCm 6.1. Two minor versions before or after the current ROCm level should work.
+
+Let's activate our environment for PyTorch.
+```
+source $HOME/venv-pt/bin/activate 
+```
+and check the available versions:
+```
+pip install --index-url https://download.pytorch.org/whl/ torch== |& grep -o '[^ ]*rocm[^ ]*'
+pip install --index-url https://download.pytorch.org/whl/ torchvision== |& grep -o '[^ ]*rocm[^ ]*'
+pip install --index-url https://download.pytorch.org/whl/ torchaudio== |& grep -o '[^ ]*rocm[^ ]*'
+```
+It should yield something like:
+```
+...
+2.2.2+rocm5.6
+2.2.2+rocm5.7
+...
+0.17.2+rocm5.6
+0.17.2+rocm5.7
+...
+2.2.2+rocm5.6
+2.2.2+rocm5.7
+```
+Great, we can install the latest versions of each package:
+```
+pip install --index-url https://download.pytorch.org/whl/ \
+  torch==2.2.2+rocm5.7 \
+  torchvision==0.17.2+rocm5.7 \
+  torchaudio==2.2.2+rocm5.7
+```
+Quick smoke tests to see if PyTorch can detect all GPUs:
+```
+python3 -c 'import torch; print("I have this many devices:", torch.cuda.device_count())'
+```
+I should see `I have this many devices: 8`
+
+Let's install TensorFlow in its respective environment.
+
+```
+deactivate
+source $HOME/venv-tf/bin/activate 
+pip install tensorflow-rocm==
+```
+We have available TensorFlow 2.14.0 for ROCm 6.0. Let's use that version and do a quick smoke tests to see if TensorFlow detects our GPUs:
+```
+pip install tensorflow-rocm==2.14.0.600
+python3 -c 'from tensorflow.python.client import device_lib ; device_lib.list_local_devices()'
+```
+It should yield:
+```
+2024-04-18 11:40:20.107002: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1886] Created device /device:GPU:0 with 63922 MB memory:  -> device: 0, name: AMD Instinct MI210, pci bus id: 0000:63:00.0
+2024-04-18 11:40:20.333720: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1886] Created device /device:GPU:1 with 63922 MB memory:  -> device: 1, name: AMD Instinct MI210, pci bus id: 0000:43:00.0
+2024-04-18 11:40:20.552465: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1886] Created device /device:GPU:2 with 63922 MB memory:  -> device: 2, name: AMD Instinct MI210, pci bus id: 0000:03:00.0
+2024-04-18 11:40:20.778092: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1886] Created device /device:GPU:3 with 63922 MB memory:  -> device: 3, name: AMD Instinct MI210, pci bus id: 0000:26:00.0
+2024-04-18 11:40:21.014425: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1886] Created device /device:GPU:4 with 63922 MB memory:  -> device: 4, name: AMD Instinct MI210, pci bus id: 0000:e3:00.0
+2024-04-18 11:40:21.235818: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1886] Created device /device:GPU:5 with 63922 MB memory:  -> device: 5, name: AMD Instinct MI210, pci bus id: 0000:c3:00.0
+2024-04-18 11:40:21.460124: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1886] Created device /device:GPU:6 with 63922 MB memory:  -> device: 6, name: AMD Instinct MI210, pci bus id: 0000:83:00.0
+2024-04-18 11:40:21.683632: I tensorflow/core/common_runtime/gpu/gpu_device.cc:1886] Created device /device:GPU:7 with 63922 MB memory:  -> device: 7, name: AMD Instinct MI210, pci bus id: 0000:a3:00.0
+```
+We are interested in using Horovod with TensorFlow, so let's install it. Horovod build system was not made ready to ROCm 6.0+, so we need to provide some help to identify the new location for the Cmake files:
+```
+mkdir -p $HOME/cmake
+cat > $HOME/cmake/cmake << EOF
+#!/bin/bash -e
+
+if [[ "\$@" == *"--build"* ]] ; then
+  $(which cmake) \$@ 
+else
+  $(which cmake) -DCMAKE_MODULE_PATH=$ROCM_PATH/lib/cmake/hip \$@ 
+fi
+EOF
+chmod +x $HOME/cmake/cmake
+```
+
+We can now build using our tuned cmake script:
+```
+PATH=$HOME/cmake:$PATH \
+CPATH=$ROCM_PATH/include/rccl \
+HOROVOD_WITHOUT_MXNET=1 \
+  HOROVOD_WITHOUT_GLOO=1 \
+  HOROVOD_GPU=ROCM \
+  HOROVOD_ROCM_HOME=$ROCM_PATH \
+  HOROVOD_GPU_OPERATIONS=NCCL \
+  HOROVOD_CPU_OPERATIONS=MPI \
+  HOROVOD_WITH_MPI=1   \
+  HOROVOD_ROCM_PATH=$ROCM_PATH \
+  HOROVOD_RCCL_HOME=$ROCM_PATH/include/rccl \
+  HOROVOD_RCCL_LIB=$ROCM_PATH/lib \
+  HCC_AMDGPU_TARGET=gfx90a,gfx942 \
+  HOROVOD_WITH_TENSORFLOW=1 \
+  HOROVOD_WITHOUT_PYTORCH=1 \
+  pip install --no-cache-dir --force-reinstall --verbose horovod==0.28.1
+  ```
+Let's define a work directory for us to try some examples.
+```
+mkdir -p $HOME/ai-with-rocm
+```
+## PyTorch MNIST example.
+
+MNIST is a quite popular data set for computer vision training. We are fortunate that are many examples on the internet on how to train MNIST dataset and they can usually be run without any changes.
+
+Let's take one of the PyTorch official examples for this - we are training we just two epochs:
+```
+cd $HOME/ai-with-rocm
+
+deactivate
+source $HOME/venv-pt/bin/activate 
+
+curl -LO https://raw.githubusercontent.com/pytorch/examples/main/mnist/main.py
+python -u main.py --epochs 2 --batch-size 256
+
+
+```
+We can control which GPU to use with the environmental variable ROCR_VISIBLE_DEVICES and can use the `rocprof` to get more of an idea about the GPU activity:
+
+```
+ROCR_VISIBLE_DEVICES=2 \
+  rocprof python -u main.py --epochs 1 --batch-size 256
+```
+The resulting file `results.csv` show the different GPU kernels invoked for this application.
+
+## PyTorch MNIST example - distributed.
+
+We might now be interested in distributing our training accross devices. A way to accomplish this is by taking a distributed data-parallel (DDP) approach where each GPU will train different batch independently and combine the results afterwards. 
+
+There are also several examples on how to do this. We will use as starting example https://raw.githubusercontent.com/kubeflow/examples/master/pytorch_mnist/training/ddp/mnist/mnist_DDP.py.
+
+```
+cd $HOME/ai-with-rocm
+curl -LO https://raw.githubusercontent.com/kubeflow/examples/master/pytorch_mnist/training/ddp/mnist/mnist_DDP.py
+```
+
+Download a modified version of this script and compare the differences:
+
+```
+curl -LO https://raw.githubusercontent.com/amd/HPCTrainingExamples/main/MLExamples/mnist_DDP_modified.py
+diff mnist_DDP.py mnist_DDP_modified.py
+```
+
+There are a couple of differences one controls the batch size another one controls how the distributed run is initialized.
+```
+dist.init_process_group(backend='nccl', 
+                        init_method='env://', 
+                        world_size=int(os.environ['WORLD_SIZE']),                             rank=int(os.environ['RANK']))
+```
+
+PyTorch provides an object to control the distributed run environment:
+```
+import torch.distributed as dist
+```
+Here we are instructing that we want to use RCCL (AMD implementation for NCCL) and also want the tool to leverage the environment to collect more information, with some explicit information about the number of ranks (world size) and rank.
+
+Other relevant bits to enable distributed run are in:
+```
+def run(modelpath, gpu):
+  ...
+  model = Net()
+  ...
+  model = torch.nn.parallel.DistributedDataParallel(model)
+  ...
+  optimizer = optim.SGD(model.parameters(), lr=0.01, momentum=0.5)
+  ...
+```
+Here the model is wrapped into the `DistributedDataParallel` object to enable the distributed training.
+
+Now to train the model on multiple ranks we will leverage MPI to start the processes and translate the MPI environment to something that PyTorch distributed package understands:
+
+```
+cat > run-me.sh << EOF
+#!/bin/bash -e
+  export MASTER_ADDR=localhost
+  export MASTER_PORT=29500
+  export WORLD_SIZE=\$OMPI_COMM_WORLD_SIZE
+  export RANK=\$OMPI_COMM_WORLD_RANK
+  export ROCR_VISIBLE_DEVICES=\$OMPI_COMM_WORLD_LOCAL_RANK
+  
+  python -u mnist_DDP_modified.py \
+    --gpu --modelpath $HOME/ai-with-rocm/model
+
+EOF
+chmod +x run-me.sh
+
+mpirun -np 2 ./run-me.sh
+```
+
+Master address and port are defined for the different ranks to communicate between themselves. We then leverage the `OMPI_*` variables to decide ranks and GPUs to be used by each of these ranks.
+
+Another popular way to spin a distributed run is to leverage the `torchrun` utility. However, this requires the application to include logic to decide which GPU to use, instead of relying on `ROCR_VISIBLE_DEVICES`. We can add the following line to our application after `dist.init_process_group()` to accomplish that:
+
+```
+torch.cuda.set_device(int(os.environ['RANK']))
+```
+This will make GPUs to be indexed by the rank.
+
+We can then run our application with `torchrun` as:
+```
+ROCR_VISIBLE_DEVICES=0,1 \
+  torchrun --nnodes 1 --nproc_per_node 2 \
+    ./mnist_DDP_modified.py --gpu --modelpath $HOME/ai-with-rocm/model
+```
+
+## TensorFlow with Horovod example
+
+Similarly to PyTorch, TensorFlow examples should not need changes due to the GPU architecture.
+
+Let's pick up TensorFlow example from the Horovod project - a syntectic training example already rigged to use Horovod:
+```
+deactivate
+source $HOME/venv-tf/bin/activate 
+cd $HOME/ai-with-rocm
+
+curl -LO https://raw.githubusercontent.com/horovod/horovod/master/examples/tensorflow2/tensorflow2_synthetic_benchmark.py
+
+mpirun -np 2 \
+  python -u tensorflow2_synthetic_benchmark.py --batch-size 256
+```
+
+Horovod makes it rather straingforward to start a distributed learning model as it leverages the already existing MPI environment.
+
+We can inspect the test case and see the relevant bits where Horovod `hvd` is being leveraged, namely the selection of the GPU based on the local rank and wrapping of the local Gradient Tape operator.
+```
+import tensorflow as tf
+import horovod.tensorflow as hvd
+...
+tf.config.experimental.set_visible_devices(gpus[hvd.local_rank()], 'GPU')
+...
+    with tf.GradientTape() as tape:
+...
+    tape = hvd.DistributedGradientTape(tape, compression=compression)
+```
+
+We can further inspect the GPU activity by leveraging `rocprof` to obtain a trace for one of the ranks. We'll do just 2 iterations so that the result files are not too large. 
+```
+mpirun -np 2 \
+  bash -c 'if [ $OMPI_COMM_WORLD_RANK -eq 1 ] ; then \
+             profiler="rocprof --hip-trace" ; \
+           fi ; \
+           $profiler python -u tensorflow2_synthetic_benchmark.py \
+             --batch-size 256 \
+             --num-warmup-batches 2 \
+             --num-iters 2'
+            
+```
+We will get a `results.json` file with the trace information to load in the Perfetto tool. It is often a good idea to compress the file to make it easier to copy to one's workstation.
+```
+xz -T8 -9 results.json
+```
+We can then copy it and visualize in Perfetto. We can detect the kernesl from the different libraries, like MIOpen, rocBLAS, Eigen as well as MLIR JIT kernels.
+![image](https://hackmd.io/_uploads/B1SpcGyW0.png)
+
+## Examples with Huggingface transformers
+
+There are several repositories of examples. A popular one is the Huggingface transformers. These examples should just work without any modification specific to AMD GPUs.
+
+We can install the transformaer package from source as:
+```
+deactivate
+source $HOME/venv-tf/bin/activate 
+
+git clone \
+https://github.com/huggingface/transformers.git \
+  $HOME/ai-with-rocm/transformers
+cd $HOME/ai-with-rocm/transformers
+pip3 install -e .
+```
+
+It is useful to point the implementation to a suitable plce to store and cache information and datasets. That can be done by setting the environment variables: 
+```
+export HF_HOME=$HOME/ai-with-rocm/hf-home
+export HUGGINGFACE_HUB_CACHE=$HOME/ai-with-rocm/hf-cache
+mkdir -p $HF_HOME $HUGGINGFACE_HUB_CACHE 
+```
+We can now try the examples. 
+
+### Image calssification
+Let's look at the image classification one. We need first to install the example dependences:
+``` 
+cd $HOME/ai-with-rocm/transformers/examples/pytorch/image-classification
+pip3 install -r requirements.txt
+pip3 install scikit-learn
+pip3 install -U pillow 
+```
+We are now ready to run the example. We'll be experimenting with using mixed precision (with BF16 datatypes) or not (the default):
+```
+for precision in '' '--bf16' ; do
+  ROCR_VISIBLE_DEVICES=2 \
+    python3 run_image_classification.py \
+      --dataset_name beans \
+      --label_column_name labels \
+      --output_dir $HOME/ai-with-rocm/hf-output  \
+      --overwrite_output_dir \
+      --remove_unused_columns False \
+      --do_train \
+      --learning_rate 2e-5 \
+      --num_train_epochs 2 \
+      --per_device_train_batch_size 8 \
+      --torch_compile True \
+      --seed 1337 \
+      $precision
+done
+```
+Depending on what is bounding the performance it could be good idea to use mixed precision or not - so this is a fair experiment to do. This should yield results like:
+
+```
+...
+# No mixed precision
+***** train metrics *****                                                               
+  epoch                    =         2.0
+  total_flos               = 149248978GF
+  train_loss               =      0.4118
+  train_runtime            =  0:01:17.52
+  train_samples_per_second =      26.675
+  train_steps_per_second   =       3.354
+...
+# With mixed precision (BF16)
+***** train metrics *****
+  epoch                    =         2.0
+  total_flos               = 149248978GF
+  train_loss               =      0.4126
+  train_runtime            =  0:01:23.73
+  train_samples_per_second =      24.698
+  train_steps_per_second   =       3.105
+```
+
+### Language modeling
+A growing set of applications for distributed learning is language modelling. A typical approach is to leverage an established model and fine tune it for one needs. That's what the `question-answering` example does. We'll start our fine-tuning from the BERT base dataset. The steps are similar to what we did before: first install the requirements:
+
+```
+cd $HOME/ai-with-rocm/transformers/examples/pytorch/question-answering
+pip3 install -r requirements.txt
+```
+Then, we are ready to run the fine-tuning, e.g., on 2 GPUs for different training precisions:
+```
+for precision in '' '--bf16' '--fp16' ; do
+ROCR_VISIBLE_DEVICES=0,1 \
+  torchrun --nproc_per_node 2  run_qa.py \
+    --model_name_or_path bert-base-uncased \
+    --dataset_name squad \
+    --do_train \
+    --per_device_train_batch_size 12 \
+    --learning_rate 3e-5 \
+    --num_train_epochs 1 \
+    --max_seq_length 384 \
+    --doc_stride 128 \
+    --output_dir $HOME/ai-with-rocm/hf-output2  \
+    --torch_compile True \
+    --overwrite_output_dir \
+    $precision
+done
+```
+
+
+
+```
+# FP32
+***** train metrics *****
+  epoch                    =        1.0
+  total_flos               = 16159030GF
+  train_loss               =     1.3039
+  train_runtime            = 0:10:09.70
+  train_samples            =      88524
+  train_samples_per_second =    145.192
+  train_steps_per_second   =      6.051
+ 
+ # BF16
+***** train metrics *****
+  epoch                    =        1.0
+  total_flos               = 16159030GF
+  train_loss               =     1.3013
+  train_runtime            = 0:07:34.81
+  train_samples            =      88524
+  train_samples_per_second =    194.636
+  train_steps_per_second   =      8.111
+ 
+ # FP16
+ ***** train metrics *****
+  epoch                    =        1.0
+  total_flos               = 16159030GF
+  train_loss               =     1.3064
+  train_runtime            = 0:06:35.75
+  train_samples            =      88524
+  train_samples_per_second =    223.686
+  train_steps_per_second   =      9.322
+ ```
+ 
+## Note about MI300
+
+For MI300 series, the publically available wheels files might not contain the support for it yet. Though this is gahnging eminently, you might have to, e.g. leverage the files in https://repo.radeon.com/rocm/manylinux/. E.g. to install PyTorch and run the MNIST example above we could do:
+
+```
+deactivate
+
+python3 -m venv --system-site-packages $HOME/venv-pt-mi300
+source $HOME/venv-pt-mi300/bin/activate 
+
+pip install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.0.2/torch-2.1.2%2Brocm6.0-cp310-cp310-linux_x86_64.whl
+pip install https://repo.radeon.com/rocm/manylinux/rocm-rel-6.0.2/torchvision-0.16.1%2Brocm6.0-cp310-cp310-linux_x86_64.whl
+pip install transformers
+
+cd $HOME/ai-with-rocm
+curl -LO https://raw.githubusercontent.com/pytorch/examples/main/mnist/main.py
+python -u main.py --epochs 2 --batch-size 256
+```
+
+

--- a/README_DIR/ml_ai.md
+++ b/README_DIR/ml_ai.md
@@ -1,7 +1,3 @@
-
---------------------------------------------------------------
-\pagebreak{}
-
 # AI and ML exercises
 
 **NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.

--- a/README_DIR/rocgdb.md
+++ b/README_DIR/rocgdb.md
@@ -1,7 +1,3 @@
---------------------------------------------------------------
-
-\pagebreak{}
-
 # ROCgdb
 
 **NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.

--- a/README_DIR/rocgdb.md
+++ b/README_DIR/rocgdb.md
@@ -1,0 +1,123 @@
+--------------------------------------------------------------
+
+\pagebreak{}
+
+# ROCgdb
+
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
+
+We show a simple example on how to use the main features of the ROCm debugger `rocgdb`.
+
+## Saxpy Debugging
+
+Let us consider the `saxpy` kernel in the HIP examples: 
+
+```
+cd HPCTrainingExamples/HIP/saxpy
+```
+Get an allocation of a GPU and load software modules:
+
+```bash
+salloc -N 1 --gpus=1
+module load rocm
+```
+
+You can see some information on the GPU you will be running on by doing:
+
+```bash
+rocm-smi
+```
+
+To introduce an error in your program, comment out the `hipMalloc` calls at line 71 and 72, then compile with:
+
+```bash
+mkdir build && cd build
+cmake ..
+make VERBOSE=1
+```
+
+Running the program, you will see the expected runtime error:
+
+```bash
+./saxpy
+Memory access fault by GPU node-2 (Agent handle: 0x2284d90) on address (nil). Reason: Unknown.
+Aborted (core dumped)
+```
+
+To run the code with the `rocgdb` debugger, do:
+
+```bash
+rocgdb saxpy
+```
+
+Note that there are also two options for graphical user interfaces that can be turned on by doing:
+
+```bash
+rocgdb -tui saxpy
+cgdb -d rocgdb saxpy 
+```
+
+For the latter command above, you need to have `cgdb` installed on your system.
+
+In the debugger, type `run` (or just `r`) and you will get an error similar to this one:
+
+```bash
+Thread 3 "saxpy" received signal SIGSEGV, Segmentation fault.
+[Switching to thread 3, lane 0 (AMDGPU Lane 1:2:1:1/0 (0,0,0)[0,0,0])]
+0x00007ffff7ec1094 in saxpy() at saxpy.cpp:57
+57    y[i] += a*x[i];
+```
+
+Note that the cmake build type is set to `RelWithDebInfo` (see line 8 in CMakeLists.txt). With this build type, the debugger will be aware of the debug symbols. If that was not the case (for instance if compiling in `Release` mode), running the code with the debugger you would get an error message ***without*** line info, and also a warning like this one:
+
+```bash
+Reading symbols from saxpy...
+(No debugging symbols found in saxpy)
+```
+
+The error report is at a thread on the GPU. We can display information on the threads by typing `info threads` (or `i th`). It is also possible to move to a specific thread with `thread <ID>` (or `t <ID>`) and see the location of this thread with `where`. For instance, if we are interested in the thread with ID 1:
+
+```bash
+i th
+th 1
+where
+```
+
+You can add breakpoints with `break` (or `b`) followed by the line number. For instance to put a breakpoint right after the `hipMalloc` lines do `b 72`.
+
+When possible, it is also advised to compile without optimization flags (so using  `-O0`) to avoid seeing breakpoints placed on lines different than those specified with the breakpoint command.
+
+You can also add a breakpoint directly at the start of the GPU kernel with `b saxpy`. To run to the next breakpoint, type `continue` (or `c`). 
+
+To list all the breakpoints that have been inserted type `info break` (or `i b`):
+
+```bash
+(gdb) i b
+Num     Type           Disp Enb Address            What
+1       breakpoint     keep y   0x000000000020b334 in main() at /HPCTrainingExamples/HIP/saxpy/saxpy.hip:74
+2       breakpoint     keep y   0x000000000020b350 in main() at /HPCTrainingExamples/HIP/saxpy/saxpy.hip:78
+```
+
+A breakpoint can be removed with `delete <Num>` (or `d <Num>`): note that `<Num>` is the breakpoint ID displayed above. For instance, to remove the breakpoint at line 74, you have to do `d 1`. 
+
+To proceed to the next line you can do `next` (or `n`).  To step into a function, do `step` (or `s`) and to get out do `finish`. Note that if a breakpoint is at a kernel, doing `n` or `s` will switch between different threads. To avoid this behavior, it is necessary to disable the breakpoint at the kernel with `disable <Num>`.
+
+It is possible to have information on the architecture (below shown on MI250):
+
+```bash
+(gdb) info agents
+  Id State Target Id                  Architecture Device Name                             Cores Threads Location
+* 1  A     AMDGPU Agent (GPUID 64146) gfx90a       Aldebaran/MI200 [Instinct MI250X/MI250] 416   3328    29:00.0
+``` 
+
+We can also get information on the thread grid:
+
+```bash
+(gdb) info dispatches
+  Id   Target Id                      Grid      Workgroup Fence   Kernel Function
+* 1    AMDGPU Dispatch 1:1:1 (PKID 0) [256,1,1] [128,1,1] B|Aa|Ra saxpy(int, float const*, int, float*, int)
+```
+
+For the rocgdb documentation, please see: `/opt/rocm-<version>/share/doc/rocgdb`.
+

--- a/README_DIR/rocprof.md
+++ b/README_DIR/rocprof.md
@@ -1,5 +1,3 @@
-\pagebreak{}
-
 # Rocprof
 
 **NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.

--- a/README_DIR/rocprof.md
+++ b/README_DIR/rocprof.md
@@ -1,0 +1,129 @@
+\pagebreak{}
+
+# Rocprof
+
+**NOTE**: these exercises have been tested on MI210 and MI300A accelerators using a container environment.
+To see details on the container environment (such as operating system and modules available) please see `README.md` on [this](https://github.com/amd/HPCTrainingDock) repo.
+
+We discuss an example on how to use the tools from `rocprof`.
+
+## Initial Setup
+
+First, setup the environment:
+
+```bash
+salloc --cpus-per-task=8 --mem=0 --ntasks-per-node=4 --gpus=1
+module load rocm
+```
+
+Download the examples repo and navigate to the `HIPIFY` exercises:
+
+```bash
+cd ~/HPCTrainingExamples/HIPIFY/mini-nbody/hip/
+```
+
+Update the bash scripts with `$ROCM_PATH`:
+
+```bash
+sed -i 's/\/opt\/rocm/${ROCM_PATH}/g' *.sh
+```
+
+Compile and run the `nbody-orig.hip` program (the script below will do both, for several values of `nBodies`):
+
+```bash
+./HIP-nbody-orig.sh
+```
+
+To compile explicitly without `make` you can do (considering for example `nbody-orig`):
+
+```bash
+hipcc -I../ -DSHMOO nbody-orig.hip -o nbody-orig
+```
+
+And then run with:
+
+```bash
+./nbody-orig <nBodies>
+```
+
+The procedure for compiling and running a single example applies to the other programs in the directory. The default value for `nBodies` is 30000 for all the examples.
+
+##  Run ROCprof and Inspect the Output
+
+Run `rocprof` to obtain the hotspots list (considering for example `nbody-orig`):
+
+```bash
+rocprof --stats --basenames on nbody-orig 65536
+```
+
+In the above command, the `--basenames on` flag removes the kernel arguments from the output, for ease of reading. Throughout this example, we will always use 65536 as a value for `nBodies`, since `nBodies` is used to define the number of work groups in the thread grid:
+
+```bash
+nBlocks = (nBodies + BLOCK_SIZE - 1) / BLOCK_SIZE
+``` 
+
+Check `results.csv` to find, for each invocation of each kernel, details such as grid size (`grd`), workgroup size (`wgr`), LDS used (`lds`), scratch used if register spilling happened (`scr`), number of SGPRs and VGPRs used, etc. Note that grid size is equal to the total number of ***work-items (threads)***, not the number of work groups. This is the output that is useful if you allocate shared memory dynamically, for instance.
+
+Additionally, you can check the statistics result file called `results.stats.csv`, displayed one line per kernel, sorted in descending order of durations.
+
+You can trace HIP, GPU and Copy activity with `--hip-trace`: 
+
+```bash
+rocprof --hip-trace nbody-orig 65536
+```
+
+The output is the file `results.hip_stats.csv`, which lists the HIP API calls and their durations, sorted in descending order. This can be useful to find HIP API calls that may be bottlenecks.
+
+You can also profile the HSA API by adding the `--hsa-trace` option. This is useful if you are profiling OpenMP target offload code, for instance, as the compiler implements all GPU offloading via the HSA layer:
+
+```bash
+rocprof --hip-trace --hsa-trace nbody-orig 65536
+```
+
+In addition to`results.hip_stats.csv`, the command above will create the file `results.hsa_stats.csv` which contains the statistics information for HSA calls.
+
+## Visualization with Perfetto
+
+The `results.json` JSON file produced by `rocprof` can be downloaded to your local machine and viewed in Perfetto UI. This file contains the timeline trace for this application, but shows only GPU, Copy and HIP API activity. 
+
+Once you have downloaded the file, open a browser and go to [https://ui.perfetto.dev/](https://ui.perfetto.dev/).
+Click on `Open trace file` in the top left corner.
+Navigate to the `results.json` you just downloaded.
+Use WASD to navigate the GUI
+
+![image](https://user-images.githubusercontent.com/109979778/225451481-46ffd521-2453-4caa-8d28-fa4e0f4c4889.png)
+
+To read about the GPU hardware counters available, inspect the output of the following command:
+
+```bash
+less $ROCM_PATH/lib/rocprofiler/gfx_metrics.xml
+```
+
+In the output displayed, look for the section associated with the hardware on which you are running (for instance gfx90a).
+
+Create a `rocprof_counters.txt` file with the counters you would like to collect, for instance:
+
+```bash
+touch rocprof_counters.txt
+```
+
+and write this in `rocprof_counters.txt` as an example:
+
+```bash
+pmc : Wavefronts VALUInsts
+pmc : SALUInsts SFetchInsts GDSInsts
+pmc : MemUnitBusy ALUStalledByLDS
+```
+
+Execute with the counters we just added, including the `timestamp on` option which turns on GPU kernel timestamps:
+
+```bash
+rocprof --timestamp on -i rocprof_counters.txt  nbody-orig 65536
+```
+
+You'll notice that `rocprof` runs 3 passes, one for each set of counters we have in that file.
+
+View the contents of `rocprof_counters.csv` for the collected counter values for each invocation of each kernel:
+
+```bash
+cat rocprof_counters.csv

--- a/login_info/AAC/README.md
+++ b/login_info/AAC/README.md
@@ -1,0 +1,197 @@
+\pagebreak{}
+
+# AMD Accelerator Cloud (AAC)
+To support trainings, we can upload training containers to the AMD Accelerator Cloud (AAC), and have attendees login using the instructions below. This set of instructions assumes that users have already received their `<username>` and `<port_number>` for the container, and that they have either provided an ssh key to the training team, or they have received a password from the training team.
+
+## Login Instructions
+The instructions below rely on ssh to access the AAC. Remember that when a container is brought down, it will not be possible to access the user data on it, so make sure to backup your data frequently if you want to keep it.
+
+### SSH-Key Generation
+Generate an ssh key on your local system, which will be stored in `.ssh`:
+```bash
+cd $HOME
+ssh-keygen -t ed25519 -N ''
+```
+
+To  examine the content of your public key do:
+```bash
+cat $HOME/.ssh/id_ed25519.pub
+```
+
+**NOTE**: at first login, you will be presented with the AAC user agreement form. This covers the terms of use of the compute hardware as well as how we will handle your data. Scroll down with the down arrow and type `yes` when prompted. Note that if you will scroll down too much, then `no` will be received as answer and you will be logged out.
+
+### Login with SSH-Key
+
+**IMPORTANT**: if you are supposed to login with an ssh key and you are prompted a password, do not type any password!
+Instead, type `Ctrl+C` and contact us to let us know about the incident.
+
+To login to AAC using the ssh key use the `<username>` and `<port_number>` that the training team has provided you, for instance:
+```bash
+ssh <username>@aac1.amd.com -i <path/to/ssh/key> -p <port_number> (1)
+```
+
+### Login with password
+The command is the same as in `(1)`, except that it is not necessary to specify a path to the ssh key. Just type the password that has been given to you when prompted:
+```bash
+ssh <username>@aac1.amd.com -p <port_number> 
+```
+**IMPORTANT**: It is fundamental to not type the wrong password more than two times otherwise your I.P. address will be blacklisted and you will not be allowed access to AAC until we modify our firewall to get you back in. This is especially important if you are at an event where all the attendees are connecting to the same wireless network.
+
+In the commands above, `-p` refers to the port number and `-i` points to the path of your ssh key. Note that different port numbers
+will be associated with different containers on the AAC, and anytime a container is brought up, the port number will change in general.
+ 
+To simplify the login even further, you can add the following to your `.ssh/config` file:
+
+```bash
+# AMD AAC cluster
+Host aac
+   User <username>
+   Hostname aac1.amd.com // this may be different depending on the container
+   IdentityFile <path/to/ssh/key>
+   Port <port_number>
+   ServerAliveInterval 600
+   ServerAliveCountMax 30
+```
+The `ServerAlive*` lines in the config file may be added to avoid timeouts when idle. you can then login using:
+```bash
+ssh aac -p <port_number>
+```
+It may also happen that a message like the following will show after logging into AAC:
+```bash
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
+Someone could be eavesdropping on you right now (man-in-the-middle attack)!
+It is also possible that a host key has just been changed.
+```
+In such a case, remove in your local system the offending keys located in `.ssh/known_hosts`, as indicated by the warning message.
+
+### Login Troubleshooting
+Here are some troubleshooting tips if you cannot login to AAC following the instructions above:
+
+1. Check the spelling of the command ssh, in particular `<username>`, ` <port_number>` and password. 
+2. Turn off VPN if on.
+3. Try logging in from a different machine if available (and migrate the ssh key to the new machine or generate a new one and send it to us).
+4. Try a ***jump host***: this is a local server that you ssh to and then do a second ssh command from there.
+
+In case none of these options work, send us the output of the ssh command followed by `-vv` and also the output of `traceroute aac1.amd.com`. Additionally, let us know if the command `ping aac1.amd.com` works on your end.
+
+
+### Directories and Files
+
+Persistent storage is at `/datasets/teams/hackathon-testing/<username>`. Your home directory will be set to this directory: 
+
+```bash
+$HOME=/datasets/teams/hackathon-testing/<username>
+```
+Files in the above directory will persist across container starts and stops and even be available from another container with the same `<username>` on systems at the same hosting location. Remember that it will not be possible to retrieve your data once the container has been brought down.
+
+You can copy files in or out of AAC with the `scp` or the `rsync` command.
+
+Copy into AAC from your local system, for instance:
+
+```bash
+scp -i <path/to/ssh/key> -P <port_number> <file> <username>@aac1.amd.com:~/<path/to/file>
+```
+Copy from AAC to your local system:
+
+```bash
+scp -i <path/to/ssh/key> -P <port_number> <username>@aac1.amd.com:~/<path/to/file> .
+```
+
+To copy files in or out of the container, you can also use `rsync` as shown below:
+```bash
+rsync -avz -e "ssh -i <path/to/ssh/key> -p <port_number>" <file> <username>@aac1.amd.com:~/<path/to/file>
+```
+
+## Container Environment
+
+Please consult the container's [README](https://github.com/amd/HPCTrainingDock/blob/main/README.md) to learn about the latest specs of the training container.
+
+<!---The container is based on the Ubuntu 22.04 Operating System with the ROCm 6.0.2 software stack. It contains multiple versions of AMD, GCC, and LLVM compilers, hip libraries, GPU-Aware MPI (OpenMPI and MVAPICH), and AMD Profiling tools with perfetto and graphana. The container also has modules set up with the lua modules package and a slurm package and configuration. It includes the following additional packages:
+
+- emacs
+- vim
+- autotools
+- cmake
+- tmux
+- boost
+- eigen
+- fftw
+- gmp
+- gsl
+- hdf5-openmpi
+- lapack
+- magma
+- matplotlib
+- parmetis
+- mpfr
+- mpi4py
+- openblas
+- openssl
+- swig
+- numpy
+- scipy
+- h5sparse
+
+### Explore Modules
+
+To see what modules are available do:
+```bash
+module avail 
+```
+
+The output list of `module avail` should show:
+
+```
+----------------------------- /etc/lmod/modules/Linux ------------------------------------------   
+clang/base    clang/14    clang/15 (D)    gcc/base    gcc/11 (D)    gcc/12    gcc/13	miniconda/23.11.0
+----------------------------- /etc/lmod/modules/ROCm -------------------------------------------
+amdclang/17.0-6.0.2    hipfort/6.0.2    opencl/6.0.2    rocm/6.0.2
+----------------------------- /etc/lmod/modules/ROCmPlus-MPI -----------------------------------
+mvapich2/2.3.7    openmpi/5.0.0
+----------------------------- /etc/lmod/modules/ROCmPlus-AMDResearchTools ----------------------
+omniperf/2.0.0    omnitrace/1.11.1
+----------------------------- /etc/lmod/modules/ROCmPlus-LatestCompilers -----------------------
+  amd-gcc/13.2.0    aomp/amdclang-18.0    clacc/clang-17.0.0    llvm-latest/gcc11_hipstdpar    og/gcc-develop-24-02-27
+----------------------------- /etc/lmod/modules/ROCmPlus-AI -----------------------
+cupy/13.0.0b1    pytorch/2.2
+----------------------------- /usr/share/lmod/lmod/modulefiles ---------------------------------
+Core/lmod/6.6    Core/settarg/6.6
+Where:   D:  Default Module
+```
+There are three modules associated with each ROCm version. One is the ROCm module which is needed by many of the other modules. The second is the amdclang module when using the amdclang compiler that comes bundled with ROCm. The third is the hipfort module for the Fortran interfaces to HIP.
+
+Compiler modules set the C, CXX, FC flags. Note, only one compiler module can be loaded at a time. hipcc is in the path when the rocm module is loaded. ---!>
+
+## Slurm Information
+
+The training container comes equipped with Slurm. Slurm configuration is for a single queue that is shared with the rest of the node. Run the following command to get info on Slurm: 
+
+```bash
+sinfo 
+```
+
+| PARTITION | AVAIL  | TIMELIMIT | NODES | STATE | NODELIST   |
+|-----------|--------|-----------|-------|-------|------------|
+| LocalQ    |  up    |	2:00:00  | 1     | idle  | localhost  |
+
+The Slurm `salloc` command may be used to acquire a long term session that exclusively grants access to one or more GPUs. Alternatively, the `srun` or `sbatch` commands may be used to acquire a session with one or more GPUs and only exclusively use the session for the life of the run of an application. `squeue` will show information on who is currently running jobs.
+
+<!---## Exercise Examples
+
+The exercise examples are preloaded into the `/Shared` directory: copy the files into your home directory with: 
+```bash
+mkdir -p $HOME/HPCTrainingExamples
+scp -pr /Shared/HPCTrainingExamples/* $HOME/HPCTrainingExamples/
+```
+
+### Examples Repo
+
+The examples can also be obtained from our repo, which contains all the code that we will use for the exercises discussed during the training. To clone the repo, do:
+```bash
+cd $HOME
+git clone https://github.com/amd/HPCTrainingExamples.git
+```
+---!>

--- a/login_info/AAC/README.md
+++ b/login_info/AAC/README.md
@@ -1,5 +1,3 @@
-\pagebreak{}
-
 # AMD Accelerator Cloud (AAC)
 To support trainings, we can upload training containers to the AMD Accelerator Cloud (AAC), and have attendees login using the instructions below. This set of instructions assumes that users have already received their `<username>` and `<port_number>` for the container, and that they have either provided an ssh key to the training team, or they have received a password from the training team.
 

--- a/tests/advancedopenmp_memory1.sh
+++ b/tests/advancedopenmp_memory1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 module load amdclang
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/CXX/memory_pragmas
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/CXX/memory_pragmas
 
 export LIBOMPTARGET_INFO=-1
 export OMP_TARGET_OFFLOAD=MANDATORY

--- a/tests/advancedopenmp_memory2.sh
+++ b/tests/advancedopenmp_memory2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 module load amdclang
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/CXX/memory_pragmas
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/CXX/memory_pragmas
 
 export LIBOMPTARGET_INFO=-1
 export OMP_TARGET_OFFLOAD=MANDATORY

--- a/tests/gpuawarempi_pt2pt.sh
+++ b/tests/gpuawarempi_pt2pt.sh
@@ -2,7 +2,7 @@
 module load openmpi rocm
 export OMPI_CXX=hipcc
 
-cd ~/HPCTrainingExamples/MPI-examples
+cd ${REPO_DIR}/MPI-examples
 mpicxx -o ./pt2pt ./pt2pt.cpp
 
 mpirun -n 2 ./pt2pt

--- a/tests/hip_jacobi_cmakelists.sh
+++ b/tests/hip_jacobi_cmakelists.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/HPCTrainingExamples/HIP/jacobi
+cd ${REPO_DIR}/HIP/jacobi
 
 module load rocm
 module load openmpi

--- a/tests/hip_openmp_interoperability_daxpy.sh
+++ b/tests/hip_openmp_interoperability_daxpy.sh
@@ -2,7 +2,7 @@
 export HSA_XNACK=1
 module load amdclang
 
-cd ~/HPCTrainingExamples/HIP-OpenMP/CXX/daxpy
+cd ${REPO_DIR}/HIP-OpenMP/CXX/daxpy
 make
 ./daxpy
 

--- a/tests/hip_optimizations_daxpy_1.sh
+++ b/tests/hip_optimizations_daxpy_1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/HPCTrainingExamples/HIP-Optimizations/daxpy
+cd ${REPO_DIR}/HIP-Optimizations/daxpy
 make daxpy_1
 ./daxpy_1 1000000
 

--- a/tests/hip_optimizations_daxpy_2.sh
+++ b/tests/hip_optimizations_daxpy_2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/HPCTrainingExamples/HIP-Optimizations/daxpy
+cd ${REPO_DIR}/HIP-Optimizations/daxpy
 make daxpy_2
 ./daxpy_2 1000000
 

--- a/tests/hip_optimizations_daxpy_3.sh
+++ b/tests/hip_optimizations_daxpy_3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/HPCTrainingExamples/HIP-Optimizations/daxpy
+cd ${REPO_DIR}/HIP-Optimizations/daxpy
 make daxpy_3
 ./daxpy_3 1000000
 

--- a/tests/hip_optimizations_daxpy_4.sh
+++ b/tests/hip_optimizations_daxpy_4.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/HPCTrainingExamples/HIP-Optimizations/daxpy
+cd ${REPO_DIR}/HIP-Optimizations/daxpy
 make daxpy_4
 ./daxpy_4 1000000
 

--- a/tests/hip_optimizations_daxpy_5.sh
+++ b/tests/hip_optimizations_daxpy_5.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/HPCTrainingExamples/HIP-Optimizations/daxpy
+cd ${REPO_DIR}/HIP-Optimizations/daxpy
 make daxpy_5
 ./daxpy_5 1000000
 

--- a/tests/hip_saxpy_cmakelists.sh
+++ b/tests/hip_saxpy_cmakelists.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIP/saxpy
+cd ${REPO_DIR}/HIP/saxpy
 
 mkdir build && cd build
 cmake ..

--- a/tests/hip_saxpy_makefile.sh
+++ b/tests/hip_saxpy_makefile.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIP/saxpy
+cd ${REPO_DIR}/HIP/saxpy
 
 make saxpy
 ./saxpy

--- a/tests/hip_stream_cmakelists.sh
+++ b/tests/hip_stream_cmakelists.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIP/hip-stream
+cd ${REPO_DIR}/HIP/hip-stream
 
 mkdir build && cd build
 cmake ..

--- a/tests/hip_stream_makefile.sh
+++ b/tests/hip_stream_makefile.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIP/hip-stream
+cd ${REPO_DIR}/HIP/hip-stream
 
 make stream
 ./stream

--- a/tests/hip_vectoradd_cmakelists.sh
+++ b/tests/hip_vectoradd_cmakelists.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIP/vectorAdd
+cd ${REPO_DIR}/HIP/vectorAdd
 
 mkdir build && cd build
 cmake ..

--- a/tests/hip_vectoradd_cmakelists_batch.sh
+++ b/tests/hip_vectoradd_cmakelists_batch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sbatch --wait ~/HPCTrainingExamples/HIP/vectorAdd/hip_cmakelists_batch.sh
+sbatch --wait ${REPO_DIR}/HIP/vectorAdd/hip_cmakelists_batch.sh
 
 grep PASSED! slurm-*.out
 ls

--- a/tests/hip_vectoradd_cmakelists_batch_direct.sh
+++ b/tests/hip_vectoradd_cmakelists_batch_direct.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cp ~/HPCTrainingExamples/HIP/vectorAdd/hip_cmakelists_batch.sh hip_cmakelists_batch.sh
+cp ${REPO_DIR}/HIP/vectorAdd/hip_cmakelists_batch.sh hip_cmakelists_batch.sh
 chmod +x hip_cmakelists_batch.sh
 ./hip_cmakelists_batch.sh
 

--- a/tests/hip_vectoradd_makefile.sh
+++ b/tests/hip_vectoradd_makefile.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIP/vectorAdd
+cd ${REPO_DIR}/HIP/vectorAdd
 
 make vectoradd
 ./vectoradd

--- a/tests/hip_vectoradd_makefile_batch.sh
+++ b/tests/hip_vectoradd_makefile_batch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sbatch --wait ~/HPCTrainingExamples/HIP/vectorAdd/hip_makefile_batch.sh
+sbatch --wait ${REPO_DIR}/HIP/vectorAdd/hip_makefile_batch.sh
 
 grep PASSED! slurm-*.out
 rm  slurm-*.out

--- a/tests/hip_vectoradd_makefile_batch_direct.sh
+++ b/tests/hip_vectoradd_makefile_batch_direct.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cp ~/HPCTrainingExamples/HIP/vectorAdd/hip_makefile_batch.sh hip_makefile_batch.sh
+cp ${REPO_DIR}/HIP/vectorAdd/hip_makefile_batch.sh hip_makefile_batch.sh
 chmod +x hip_makefile_batch.sh
 ./hip_makefile_batch.sh
 

--- a/tests/hipfort_gemm_global.sh
+++ b/tests/hipfort_gemm_global.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/HIPFort/hipgemm
+cd ${REPO_DIR}/HIPFort/hipgemm
 make gemm_global
 ./gemm_global
 

--- a/tests/hipfort_gemm_global_sd.sh
+++ b/tests/hipfort_gemm_global_sd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/HIPFort/hipgemm
+cd ${REPO_DIR}/HIPFort/hipgemm
 make gemm_global_sd
 ./gemm_global_sd
 

--- a/tests/hipfort_gemm_local.sh
+++ b/tests/hipfort_gemm_local.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/HIPFort/hipgemm
+cd ${REPO_DIR}/HIPFort/hipgemm
 make gemm_local
 ./gemm_local
 

--- a/tests/hipfort_gemm_local_sd.sh
+++ b/tests/hipfort_gemm_local_sd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/HIPFort/hipgemm
+cd ${REPO_DIR}/HIPFort/hipgemm
 make gemm_local_sd
 ./gemm_local_sd
 

--- a/tests/hipify_nbody.sh
+++ b/tests/hipify_nbody.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIPIFY/mini-nbody/cuda
+cd ${REPO_DIR}/HIPIFY/mini-nbody/cuda
 hipify-perl -examine nbody-orig.cu
 
 hipify-perl nbody-orig.cu > nbody-orig.cpp

--- a/tests/hipstdpar_saxpy_foreach.sh
+++ b/tests/hipstdpar_saxpy_foreach.sh
@@ -3,7 +3,7 @@
 export HSA_XNACK=1
 module load amdclang
 
-cd ~/HPCTrainingExamples/HIPStdPar/CXX/saxpy_foreach
+cd ${REPO_DIR}/HIPStdPar/CXX/saxpy_foreach
 
 make
 export AMD_LOG_LEVEL=3

--- a/tests/hipstdpar_saxpy_transform.sh
+++ b/tests/hipstdpar_saxpy_transform.sh
@@ -3,7 +3,7 @@
 export HSA_XNACK=1
 module load amdclang
 
-cd ~/HPCTrainingExamples/HIPStdPar/CXX/saxpy_transform
+cd ${REPO_DIR}/HIPStdPar/CXX/saxpy_transform
 
 make
 export AMD_LOG_LEVEL=3

--- a/tests/hipstdpar_saxpy_transform_reduce.sh
+++ b/tests/hipstdpar_saxpy_transform_reduce.sh
@@ -3,7 +3,7 @@
 export HSA_XNACK=1
 module load amdclang
 
-cd ~/HPCTrainingExamples/HIPStdPar/CXX/saxpy_transform_reduce
+cd ${REPO_DIR}/HIPStdPar/CXX/saxpy_transform_reduce
 
 make
 export AMD_LOG_LEVEL=3

--- a/tests/hipstdpar_shallowwater_orig.sh
+++ b/tests/hipstdpar_shallowwater_orig.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/HPCTrainingExamples/HIPStdPar/CXX/ShallowWater_Orig
+cd ${REPO_DIR}/HIPStdPar/CXX/ShallowWater_Orig
 
 mkdir build && cd build
 cmake ..

--- a/tests/hipstdpar_shallowwater_stdpar.sh
+++ b/tests/hipstdpar_shallowwater_stdpar.sh
@@ -3,7 +3,7 @@
 export HSA_XNACK=1
 module load amdclang
 
-cd ~/HPCTrainingExamples/HIPStdPar/CXX/ShallowWater_StdPar
+cd ${REPO_DIR}/HIPStdPar/CXX/ShallowWater_StdPar
 
 make
 #export AMD_LOG_LEVEL=3

--- a/tests/hipstdpar_shallowwater_ver1.sh
+++ b/tests/hipstdpar_shallowwater_ver1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd ~/HPCTrainingExamples/HIPStdPar/CXX/ShallowWater_Ver1
+cd ${REPO_DIR}/HIPStdPar/CXX/ShallowWater_Ver1
 
 mkdir build && cd build
 cmake ..

--- a/tests/hipstdpar_shallowwater_ver2.sh
+++ b/tests/hipstdpar_shallowwater_ver2.sh
@@ -3,7 +3,7 @@
 export HSA_XNACK=1
 module load amdclang
 
-cd ~/HPCTrainingExamples/HIPStdPar/CXX/ShallowWater_Ver2
+cd ${REPO_DIR}/HIPStdPar/CXX/ShallowWater_Ver2
 
 make
 #export AMD_LOG_LEVEL=3

--- a/tests/mpi_ghost_exchange_orig.sh
+++ b/tests/mpi_ghost_exchange_orig.sh
@@ -13,7 +13,7 @@ else
    MPI_RUN_OPTIONS="--mca coll ^hcoll"
 fi
 
-cd ~/HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
+cd ${REPO_DIR}/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
 
 cd Orig
 

--- a/tests/mpi_ghost_exchange_orig_affinity.sh
+++ b/tests/mpi_ghost_exchange_orig_affinity.sh
@@ -13,7 +13,7 @@ else
    MPI_RUN_OPTIONS="--mca coll ^hcoll"
 fi
 
-cd ~/HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
+cd ${REPO_DIR}/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
 
 cd Orig
 

--- a/tests/mpi_ghost_exchange_ver1.sh
+++ b/tests/mpi_ghost_exchange_ver1.sh
@@ -14,7 +14,7 @@ else
    MPI_RUN_OPTIONS="--mca coll ^hcoll"
 fi
 
-cd ~/HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
+cd ${REPO_DIR}/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
 
 cd Ver1
 

--- a/tests/mpi_ghost_exchange_ver2.sh
+++ b/tests/mpi_ghost_exchange_ver2.sh
@@ -14,7 +14,7 @@ else
    MPI_RUN_OPTIONS="--mca coll ^hcoll"
 fi
 
-cd ~/HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
+cd ${REPO_DIR}/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
 
 cd Ver2
 

--- a/tests/mpi_ghost_exchange_ver3.sh
+++ b/tests/mpi_ghost_exchange_ver3.sh
@@ -14,7 +14,7 @@ else
    MPI_RUN_OPTIONS="--mca coll ^hcoll"
 fi
 
-cd ~/HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
+cd ${REPO_DIR}/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
 
 cd Ver3
 

--- a/tests/mpi_ghost_exchange_ver4.sh
+++ b/tests/mpi_ghost_exchange_ver4.sh
@@ -14,7 +14,7 @@ else
    MPI_RUN_OPTIONS="--mca coll ^hcoll"
 fi
 
-cd ~/HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
+cd ${REPO_DIR}/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
 
 cd Ver4
 

--- a/tests/mpi_ghost_exchange_ver5.sh
+++ b/tests/mpi_ghost_exchange_ver5.sh
@@ -14,7 +14,7 @@ else
    MPI_RUN_OPTIONS="--mca coll ^hcoll"
 fi
 
-cd ~/HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
+cd ${REPO_DIR}/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
 
 cd Ver5
 

--- a/tests/mpi_ghost_exchange_ver6.sh
+++ b/tests/mpi_ghost_exchange_ver6.sh
@@ -14,7 +14,7 @@ else
    MPI_RUN_OPTIONS="--mca coll ^hcoll"
 fi
 
-cd ~/HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
+cd ${REPO_DIR}/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
 
 cd Ver6
 

--- a/tests/mpi_ghost_exchange_ver7.sh
+++ b/tests/mpi_ghost_exchange_ver7.sh
@@ -14,7 +14,7 @@ else
    MPI_RUN_OPTIONS="--mca coll ^hcoll"
 fi
 
-cd ~/HPCTrainingExamples/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
+cd ${REPO_DIR}/MPI-examples/GhostExchange/GhostExchange_ArrayAssign
 
 cd Ver7
 

--- a/tests/nodememmodel_managed_memory_hip1.sh
+++ b/tests/nodememmodel_managed_memory_hip1.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/ManagedMemory/vectorAdd
+cd ${REPO_DIR}/ManagedMemory/vectorAdd
 
 sed -i 's/\/opt\/rocm/${ROCM_PATH}/g' Makefile
 

--- a/tests/nodememmodel_managed_memory_hip2_xnack_off.sh
+++ b/tests/nodememmodel_managed_memory_hip2_xnack_off.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/ManagedMemory/vectorAdd
+cd ${REPO_DIR}/ManagedMemory/vectorAdd
 
 sed -i 's/\/opt\/rocm/${ROCM_PATH}/g' Makefile
 

--- a/tests/nodememmodel_managed_memory_hip2_xnack_on.sh
+++ b/tests/nodememmodel_managed_memory_hip2_xnack_on.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/ManagedMemory/vectorAdd
+cd ${REPO_DIR}/ManagedMemory/vectorAdd
 
 sed -i 's/\/opt\/rocm/${ROCM_PATH}/g' Makefile
 

--- a/tests/nodememmodel_managed_memory_hip3.sh
+++ b/tests/nodememmodel_managed_memory_hip3.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/ManagedMemory/vectorAdd
+cd ${REPO_DIR}/ManagedMemory/vectorAdd
 
 sed -i 's/\/opt\/rocm/${ROCM_PATH}/g' Makefile
 

--- a/tests/nodememmodel_managed_memory_hip4.sh
+++ b/tests/nodememmodel_managed_memory_hip4.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/ManagedMemory/vectorAdd
+cd ${REPO_DIR}/ManagedMemory/vectorAdd
 
 sed -i 's/\/opt\/rocm/${ROCM_PATH}/g' Makefile
 

--- a/tests/nodememmodel_managed_memory_hip_orig.sh
+++ b/tests/nodememmodel_managed_memory_hip_orig.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/ManagedMemory/vectorAdd
+cd ${REPO_DIR}/ManagedMemory/vectorAdd
 
 sed -i 's/\/opt\/rocm/${ROCM_PATH}/g' Makefile
 

--- a/tests/nodememmodel_openmp_atomics1.sh
+++ b/tests/nodememmodel_openmp_atomics1.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum1
 ./arraysum1

--- a/tests/nodememmodel_openmp_atomics10.sh
+++ b/tests/nodememmodel_openmp_atomics10.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum10
 export HSA_XNACK=1

--- a/tests/nodememmodel_openmp_atomics2.sh
+++ b/tests/nodememmodel_openmp_atomics2.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum2
 HSA_XNACK=1

--- a/tests/nodememmodel_openmp_atomics2_xnack_off.sh
+++ b/tests/nodememmodel_openmp_atomics2_xnack_off.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum2
 export HSA_XNACK=0

--- a/tests/nodememmodel_openmp_atomics2_xnack_on.sh
+++ b/tests/nodememmodel_openmp_atomics2_xnack_on.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum2
 export HSA_XNACK=1

--- a/tests/nodememmodel_openmp_atomics3.sh
+++ b/tests/nodememmodel_openmp_atomics3.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum3
 ./arraysum3

--- a/tests/nodememmodel_openmp_atomics3_xnack_off.sh
+++ b/tests/nodememmodel_openmp_atomics3_xnack_off.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum3
 export HSA_XNACK=0

--- a/tests/nodememmodel_openmp_atomics3_xnack_on.sh
+++ b/tests/nodememmodel_openmp_atomics3_xnack_on.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum3
 export HSA_XNACK=1

--- a/tests/nodememmodel_openmp_atomics4.sh
+++ b/tests/nodememmodel_openmp_atomics4.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum4
 ./arraysum4

--- a/tests/nodememmodel_openmp_atomics4_xnack_off.sh
+++ b/tests/nodememmodel_openmp_atomics4_xnack_off.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum4
 export HSA_XNACK=0

--- a/tests/nodememmodel_openmp_atomics4_xnack_on.sh
+++ b/tests/nodememmodel_openmp_atomics4_xnack_on.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum4
 export HSA_XNACK=1

--- a/tests/nodememmodel_openmp_atomics5.sh
+++ b/tests/nodememmodel_openmp_atomics5.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum5
 export HSA_XNACK=1

--- a/tests/nodememmodel_openmp_atomics6.sh
+++ b/tests/nodememmodel_openmp_atomics6.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum6
 export HSA_XNACK=1

--- a/tests/nodememmodel_openmp_atomics7.sh
+++ b/tests/nodememmodel_openmp_atomics7.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum7
 export HSA_XNACK=1

--- a/tests/nodememmodel_openmp_atomics8.sh
+++ b/tests/nodememmodel_openmp_atomics8.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum8
 export HSA_XNACK=1

--- a/tests/nodememmodel_openmp_atomics9.sh
+++ b/tests/nodememmodel_openmp_atomics9.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/atomics_openmp
+cd ${REPO_DIR}/atomics_openmp
 
 make arraysum9
 export HSA_XNACK=1

--- a/tests/openacc_saxpy_c_amdclang.sh
+++ b/tests/openacc_saxpy_c_amdclang.sh
@@ -2,7 +2,7 @@
 
 module load amd-clang
 
-cd HPCTrainingExamples/Pragma_Examples/OpenACC/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenACC/C/saxpy
 
 make
 ./saxpy

--- a/tests/openacc_saxpy_c_clang.sh
+++ b/tests/openacc_saxpy_c_clang.sh
@@ -2,7 +2,7 @@
 
 module load clang/15
 
-cd HPCTrainingExamples/Pragma_Examples/OpenACC/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenACC/C/saxpy
 
 make
 ./saxpy

--- a/tests/openacc_saxpy_c_gcc.sh
+++ b/tests/openacc_saxpy_c_gcc.sh
@@ -2,7 +2,7 @@
 
 module load gcc/13
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenACC/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenACC/C/saxpy
 
 make
 ./saxpy

--- a/tests/openacc_vecadd_c_amdclang.sh
+++ b/tests/openacc_vecadd_c_amdclang.sh
@@ -2,7 +2,7 @@
 
 module load amd-clang
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenACC/C/vecadd
+cd ${REPO_DIR}/Pragma_Examples/OpenACC/C/vecadd
 
 make
 ./vecadd

--- a/tests/openacc_vecadd_c_clang.sh
+++ b/tests/openacc_vecadd_c_clang.sh
@@ -2,7 +2,7 @@
 
 module load clang
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenACC/C/vecadd
+cd ${REPO_DIR}/Pragma_Examples/OpenACC/C/vecadd
 
 make
 ./vecadd

--- a/tests/openacc_vecadd_c_gcc.sh
+++ b/tests/openacc_vecadd_c_gcc.sh
@@ -2,7 +2,7 @@
 
 module load gcc/13
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenACC/C/vecadd
+cd ${REPO_DIR}/Pragma_Examples/OpenACC/C/vecadd
 
 make
 ./vecadd

--- a/tests/openacc_vecadd_f_amdflang.sh
+++ b/tests/openacc_vecadd_f_amdflang.sh
@@ -2,7 +2,7 @@
 
 module load aomp
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenACC/Fortran/vecadd
+cd ${REPO_DIR}/Pragma_Examples/OpenACC/Fortran/vecadd
 
 make
 ./vecadd

--- a/tests/openacc_vecadd_f_flang.sh
+++ b/tests/openacc_vecadd_f_flang.sh
@@ -2,7 +2,7 @@
 
 module load clang/15
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenACC/Fortran/vecadd
+cd ${REPO_DIR}/Pragma_Examples/OpenACC/Fortran/vecadd
 
 make
 ./vecadd

--- a/tests/openacc_vecadd_f_gfortran.sh
+++ b/tests/openacc_vecadd_f_gfortran.sh
@@ -2,7 +2,7 @@
 
 module load gcc/13
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenACC/Fortran/vecadd
+cd ${REPO_DIR}/Pragma_Examples/OpenACC/Fortran/vecadd
 
 make
 ./vecadd

--- a/tests/openmp_freduce_f_amdflang.sh
+++ b/tests/openmp_freduce_f_amdflang.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/freduce
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran/freduce
 
 make
 ./freduce

--- a/tests/openmp_freduce_f_flang.sh
+++ b/tests/openmp_freduce_f_flang.sh
@@ -2,7 +2,7 @@
 
 module load clang/15
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/freduce
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran/freduce
 
 make
 ./freduce

--- a/tests/openmp_freduce_f_gfortran.sh
+++ b/tests/openmp_freduce_f_gfortran.sh
@@ -2,7 +2,7 @@
 
 module load gcc/13
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/freduce
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran/freduce
 
 make
 ./freduce

--- a/tests/openmp_intro_saxpy1.sh
+++ b/tests/openmp_intro_saxpy1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy1
 ./saxpy1
 

--- a/tests/openmp_intro_saxpy1f.sh
+++ b/tests/openmp_intro_saxpy1f.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy1f
 ./saxpy1f
 

--- a/tests/openmp_intro_saxpy2.sh
+++ b/tests/openmp_intro_saxpy2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy2
 ./saxpy2
 

--- a/tests/openmp_intro_saxpy2f.sh
+++ b/tests/openmp_intro_saxpy2f.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy2f
 ./saxpy2f
 

--- a/tests/openmp_intro_saxpy3.sh
+++ b/tests/openmp_intro_saxpy3.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy3
 ./saxpy3
 

--- a/tests/openmp_intro_saxpy4.sh
+++ b/tests/openmp_intro_saxpy4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy4
 ./saxpy4
 

--- a/tests/openmp_intro_saxpy5.sh
+++ b/tests/openmp_intro_saxpy5.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy5
 ./saxpy5
 

--- a/tests/openmp_intro_saxpy6.sh
+++ b/tests/openmp_intro_saxpy6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy6
 ./saxpy6
 

--- a/tests/openmp_intro_saxpy7.sh
+++ b/tests/openmp_intro_saxpy7.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy7
 ./saxpy7
 

--- a/tests/openmp_intro_saxpy_cpu.sh
+++ b/tests/openmp_intro_saxpy_cpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make saxpy_cpu
 ./saxpy_cpu
 

--- a/tests/openmp_intro_target_data_structured.sh
+++ b/tests/openmp_intro_target_data_structured.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make target_data_structured
 ./target_data_structured
 

--- a/tests/openmp_intro_target_data_unstructured.sh
+++ b/tests/openmp_intro_target_data_unstructured.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make target_data_unstructured
 ./target_data_unstructured
 

--- a/tests/openmp_intro_target_data_update.sh
+++ b/tests/openmp_intro_target_data_update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Intro
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Intro
 make target_data_update
 ./target_data_update
 

--- a/tests/openmp_language_constructs_c_device_routine.sh
+++ b/tests/openmp_language_constructs_c_device_routine.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/device_routine
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/device_routine
 make
 ./device_routine
 

--- a/tests/openmp_language_constructs_c_device_routine_wdynglobaldata.sh
+++ b/tests/openmp_language_constructs_c_device_routine_wdynglobaldata.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/device_routine_wdynglobaldata
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/device_routine_wdynglobaldata
 make
 ./device_routine
 

--- a/tests/openmp_language_constructs_c_device_routine_wglobaldata.sh
+++ b/tests/openmp_language_constructs_c_device_routine_wglobaldata.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/device_routine_wglobaldata
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/device_routine_wglobaldata
 make
 ./device_routine
 

--- a/tests/openmp_language_constructs_c_reduction_array.sh
+++ b/tests/openmp_language_constructs_c_reduction_array.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C
 cd reduction_array
 make
 ./reduction_array

--- a/tests/openmp_language_constructs_c_reduction_scalar.sh
+++ b/tests/openmp_language_constructs_c_reduction_scalar.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C
 cd reduction_scalar
 make
 ./reduction_scalar

--- a/tests/openmp_language_constructs_fortran_complex_saxpy_amdflang.sh
+++ b/tests/openmp_language_constructs_fortran_complex_saxpy_amdflang.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran
 cd complex_saxpy
 make
 ./complex_saxpy

--- a/tests/openmp_language_constructs_fortran_complex_saxpy_gfortran.sh
+++ b/tests/openmp_language_constructs_fortran_complex_saxpy_gfortran.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amd-gcc
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran
 cd complex_saxpy
 make
 ./complex_saxpy

--- a/tests/openmp_language_constructs_fortran_dtype_derived_type.sh
+++ b/tests/openmp_language_constructs_fortran_dtype_derived_type.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran
 cd derived_types
 make dtype_derived_type
 ./dtype_derived_type

--- a/tests/openmp_language_constructs_fortran_dtype_mapper.sh
+++ b/tests/openmp_language_constructs_fortran_dtype_mapper.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran
 cd derived_types
 make dtype_mapper
 ./dtype_mapper

--- a/tests/openmp_language_constructs_fortran_dtype_pointer.sh
+++ b/tests/openmp_language_constructs_fortran_dtype_pointer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran
 cd derived_types
 make dtype_pointer
 ./dtype_pointer

--- a/tests/openmp_language_constructs_fortran_dtype_scalar_members.sh
+++ b/tests/openmp_language_constructs_fortran_dtype_scalar_members.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran
 cd derived_types
 make dtype_scalar_members
 ./dtype_scalar_members

--- a/tests/openmp_language_constructs_fortran_reduction_array.sh
+++ b/tests/openmp_language_constructs_fortran_reduction_array.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran
 cd reduction_array
 make
 ./reduction_array

--- a/tests/openmp_language_constructs_fortran_reduction_scalar.sh
+++ b/tests/openmp_language_constructs_fortran_reduction_scalar.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran
 cd reduction_scalar
 make
 ./reduction_scalar

--- a/tests/openmp_language_constructs_fortran_teams_endloop.sh
+++ b/tests/openmp_language_constructs_fortran_teams_endloop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 module load amdclang
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran
 cd teams_endloop
 make
 ./teams_endloop

--- a/tests/openmp_saxpy_c_amdclang.sh
+++ b/tests/openmp_saxpy_c_amdclang.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/saxpy
 
 make
 ./saxpy

--- a/tests/openmp_saxpy_c_amdgcc.sh
+++ b/tests/openmp_saxpy_c_amdgcc.sh
@@ -2,7 +2,7 @@
 
 module load amd-gcc
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/saxpy
 
 make
 ./saxpy

--- a/tests/openmp_saxpy_c_aomp.sh
+++ b/tests/openmp_saxpy_c_aomp.sh
@@ -2,7 +2,7 @@
 
 module load aomp
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/saxpy
 
 make
 ./saxpy

--- a/tests/openmp_saxpy_c_clacc.sh
+++ b/tests/openmp_saxpy_c_clacc.sh
@@ -2,7 +2,7 @@
 
 module load clacc
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/saxpy
 
 make
 ./saxpy

--- a/tests/openmp_saxpy_c_clang.sh
+++ b/tests/openmp_saxpy_c_clang.sh
@@ -2,7 +2,7 @@
 
 module load clang/15
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/saxpy
 
 make
 ./saxpy

--- a/tests/openmp_saxpy_c_gcc.sh
+++ b/tests/openmp_saxpy_c_gcc.sh
@@ -2,7 +2,7 @@
 
 module load gcc/13
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/saxpy
 
 make
 ./saxpy

--- a/tests/openmp_saxpy_c_og.sh
+++ b/tests/openmp_saxpy_c_og.sh
@@ -2,7 +2,7 @@
 
 module load og
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/C/saxpy
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/saxpy
 
 make
 ./saxpy

--- a/tests/openmp_vecadd_f_amdflang.sh
+++ b/tests/openmp_vecadd_f_amdflang.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/vecadd
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran/vecadd
 
 make
 ./vecadd

--- a/tests/openmp_vecadd_f_gfortran.sh
+++ b/tests/openmp_vecadd_f_gfortran.sh
@@ -2,7 +2,7 @@
 
 module load gcc/13
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/vecadd
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran/vecadd
 
 make
 ./vecadd

--- a/tests/programming_model_apu.sh
+++ b/tests/programming_model_apu.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/ManagedMemory/APU_Code
+cd ${REPO_DIR}/ManagedMemory/APU_Code
 export HSA_XNACK=1
 make gpu_code
 ./gpu_code

--- a/tests/programming_model_cpu.sh
+++ b/tests/programming_model_cpu.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/ManagedMemory/CPU_Code
+cd ${REPO_DIR}/ManagedMemory/CPU_Code
 make cpu_code
 ./cpu_code
 

--- a/tests/programming_model_gpu.sh
+++ b/tests/programming_model_gpu.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/ManagedMemory/GPU_Code
+cd ${REPO_DIR}/ManagedMemory/GPU_Code
 make gpu_code
 ./gpu_code
 

--- a/tests/programming_model_kokkos.sh
+++ b/tests/programming_model_kokkos.sh
@@ -25,7 +25,7 @@ rm -rf Kokkos_build
 
 export Kokkos_DIR=${PWDir}/Kokkos_HIP
 
-cd ~/HPCTrainingExamples/ManagedMemory/Kokkos_Code
+cd ${REPO_DIR}/ManagedMemory/Kokkos_Code
 
 # To run with managed memory
 export HSA_XNACK=1

--- a/tests/programming_model_managed_memory.sh
+++ b/tests/programming_model_managed_memory.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/ManagedMemory/Managed_Memory_Code
+cd ${REPO_DIR}/ManagedMemory/Managed_Memory_Code
 export HSA_XNACK=1
 make gpu_code
 ./gpu_code

--- a/tests/programming_model_openmp.sh
+++ b/tests/programming_model_openmp.sh
@@ -3,7 +3,7 @@ export HSA_XNACK=1
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/ManagedMemory/OpenMP_Code
+cd ${REPO_DIR}/ManagedMemory/OpenMP_Code
 make openmp_code
 ./openmp_code
 

--- a/tests/programming_model_raja.sh
+++ b/tests/programming_model_raja.sh
@@ -32,7 +32,7 @@ rm -rf Raja_build
 
 export Raja_DIR=${PWDir}/Raja_HIP
 
-cd ~/HPCTrainingExamples/ManagedMemory/Raja_Code
+cd ${REPO_DIR}/ManagedMemory/Raja_Code
 
 # To run with managed memory
 export HSA_XNACK=1

--- a/tests/rocprof_mini_nbody_basenames.sh
+++ b/tests/rocprof_mini_nbody_basenames.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIPIFY/mini-nbody/hip/
+cd ${REPO_DIR}/HIPIFY/mini-nbody/hip/
 make nbody-orig
 
 rocprof --stats --basenames on ./nbody-orig 65536

--- a/tests/rocprof_mini_nbody_hip_trace.sh
+++ b/tests/rocprof_mini_nbody_hip_trace.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIPIFY/mini-nbody/hip/
+cd ${REPO_DIR}/HIPIFY/mini-nbody/hip/
 make nbody-orig
 
 rocprof --stats --hip-trace ./nbody-orig 65536

--- a/tests/rocprof_mini_nbody_hsa_trace.sh
+++ b/tests/rocprof_mini_nbody_hsa_trace.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIPIFY/mini-nbody/hip/
+cd ${REPO_DIR}/HIPIFY/mini-nbody/hip/
 make nbody-orig
 
 rocprof --stats --hsa-trace ./nbody-orig 65536

--- a/tests/rocprof_mini_nbody_results.sh
+++ b/tests/rocprof_mini_nbody_results.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIPIFY/mini-nbody/hip/
+cd ${REPO_DIR}/HIPIFY/mini-nbody/hip/
 make nbody-orig
 
 rocprof --stats ./nbody-orig 65536

--- a/tests/rocprof_mini_nbody_stats.sh
+++ b/tests/rocprof_mini_nbody_stats.sh
@@ -2,7 +2,7 @@
 
 module load rocm
 
-cd ~/HPCTrainingExamples/HIPIFY/mini-nbody/hip/
+cd ${REPO_DIR}/HIPIFY/mini-nbody/hip/
 make nbody-orig
 
 rocprof --stats ./nbody-orig 65536

--- a/tests/runTests.sh
+++ b/tests/runTests.sh
@@ -1,13 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
-git clone https://github.com/amd/HPCTrainingExamples.git
-
-mkdir TestExamples
-cp /Examples/TestExamples/* TestExamples
-cd TestExamples
-
-mkdir build && cd build
-cmake ..
+rm -rf build
+mkdir build 
+cd build 
+cmake .. 
 make test
-
                                                                       

--- a/tests/test_examples.sh
+++ b/tests/test_examples.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rm -rf HPCTrainingExamples
+rm -rf ${REPO_DIR}
 git clone https://github.com/amd/HPCTrainingExamples.git
 
 #Slurm interactive test
@@ -8,7 +8,7 @@ git clone https://github.com/amd/HPCTrainingExamples.git
 #salloc -N 1 -p LocalQ --gpus=1 -t 10:00
 
 module load rocm
-cd ~/HPCTrainingExamples/HIP/vectorAdd
+cd ${REPO_DIR}/HIP/vectorAdd
 make vectoradd
 ./vectoradd
 make clean
@@ -22,7 +22,7 @@ cd
 
 # need to add slurm example
 
-cd ~/HPCTrainingExamples/HIP/hip-stream
+cd ${REPO_DIR}/HIP/hip-stream
 make stream
 ./stream
 make clean
@@ -34,7 +34,7 @@ cd ..
 rm -rf build
 cd
 
-cd ~/HPCTrainingExamples/HIP/saxpy
+cd ${REPO_DIR}/HIP/saxpy
 make saxpy
 ./saxpy
 make clean
@@ -46,7 +46,7 @@ cd ..
 rm -rf build
 cd
 
-cd ~/HPCTrainingExamples/HIP/jacobi
+cd ${REPO_DIR}/HIP/jacobi
 
 module load rocm
 module load openmpi
@@ -62,7 +62,7 @@ cd ..
 rm -rf build
 cd
 
-cd HPCTrainingExamples/HIPIFY/mini-nbody/cuda
+cd ${REPO_DIR}/HIPIFY/mini-nbody/cuda
 hipify-perl -examine nbody-orig.cu
 
 hipify-perl nbody-orig.cu > nbody-orig.cpp
@@ -104,14 +104,14 @@ cd PENNANT
 make
 build/pennant test/leblanc/leblanc.pnt
 
-cp ~/HPCTrainingExamples/HIP/saxpy/Makefile .
-cp ~/HPCTrainingExamples/HIP/saxpy/CMakeLists.txt .
+cp ${REPO_DIR}/HIP/saxpy/Makefile .
+cp ${REPO_DIR}/HIP/saxpy/CMakeLists.txt .
 cp Makefile Makefile.portable
 cp CMakeLists.txt CMakeLists.txt.portable
 cp ~/Makefile .
 cp ~/CMakeLists.txt .
 
-cd HPCTrainingExamples/Pragma_Examples/OpenMP/C/Make/saxpy/
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/Make/saxpy/
 module load rocm
 module load amdclang
 make
@@ -120,7 +120,7 @@ make clean
 
 cd
 
-cd HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/Make/freduce
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran/Make/freduce
 module load rocm
 module load amdclang
 make

--- a/tests/usm_vector_add.sh
+++ b/tests/usm_vector_add.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/USM/vector_add_usm
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/USM/vector_add_usm
 make
 make run
 

--- a/tests/usm_vector_auto_zero_copy.sh
+++ b/tests/usm_vector_auto_zero_copy.sh
@@ -2,7 +2,7 @@
 
 module load amdclang
 
-cd ~/HPCTrainingExamples/Pragma_Examples/OpenMP/USM/vector_add_auto_zero_copy
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/USM/vector_add_auto_zero_copy
 make
 make run
 


### PR DESCRIPTION
1. Added READMEs that are taken from the latest training instructions (HLRS). Some have been added to the associated directory of exercises. Others (such as Rocprof and Rocgdb) have been placed in a dir `README_DIR` that collects READMEs that are not currentl directly associated with exercises in the repo but that we should still keep track of.

2. Added `REPO_DIR` environment variable read to the test scripts so that it is not expected anymore that the repo is cloned in the home directory.

3. Started a top level README.md file where we will provide information on the repo content structure. Might have to do a per-task sorting rather than a per-topic.

4. Added a `login_instructions` dir to keep track of log in instructions such as those necessary to ssh into AAC.