### PR TITLE
Fixing wrong path in README documentation

### DIFF
--- a/Pragma_Examples/README.md
+++ b/Pragma_Examples/README.md
@@ -5,7 +5,7 @@ To see details on the container environment (such as operating system and module
 
 ## Checking out makefiles and compiler toolchain
 
-Running the first OpenMP example: `Pragma_Examples/OpenMP/C/Make/saxpy`
+Running the first OpenMP example: `Pragma_Examples/OpenMP/C/saxpy`
 
 ### Build with AMDClang compiler
 

--- a/Pragma_Examples/runtest.sh
+++ b/Pragma_Examples/runtest.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
-for dir in OpenMP/C/Make/vecadd OpenMP/Fortran/Make/vecadd OpenMP/Fortran/Make/freduce OpenACC/C/Make/vecadd OpenACC/Fortran/Make/vecadd OpenACC/Fortran/Make/freduce OpenMP/C/Make/saxpy OpenACC/C/Make/saxpy OpenMP/C/Make/reduction OpenACC/C/Make/reduction
+#!/bin/bash
+module load aomp
+for dir in OpenMP/C/vecadd OpenMP/Fortran/vecadd OpenMP/Fortran/freduce OpenACC/C/vecadd OpenACC/Fortran/vecadd OpenACC/Fortran/freduce OpenMP/C/saxpy OpenACC/C/saxpy OpenMP/C/reduction OpenACC/C/reduction
 do
   pushd $dir
   make

--- a/tests/test_examples.sh
+++ b/tests/test_examples.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 REPO_DIR="$(dirname "$(dirname "$(readlink -fm "$0")")")"
-rm -rf ${REPO_DIR}
-git clone https://github.com/amd/HPCTrainingExamples.git
 
 #Slurm interactive test
 
@@ -116,7 +114,7 @@ cp CMakeLists.txt CMakeLists.txt.portable
 cp ~/Makefile .
 cp ~/CMakeLists.txt .
 
-cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/Make/saxpy/
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/C/saxpy/
 module load rocm
 module load amdclang
 make
@@ -125,7 +123,7 @@ make clean
 
 cd
 
-cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran/Make/freduce
+cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran/freduce
 module load rocm
 module load amdclang
 make


### PR DESCRIPTION
This one is only in the documentation, so it is a simple fix. 

I think there might be other places in `Pragma_Examples/runtest.sh` and `tests/test_examples.sh` where a similar fix is needed. However, since these are the scripts and I dont know how and where they are already used, I am hesitant to fix those now myself.