### PR TITLE
Modified run command for mvapich2 OMB script

### DIFF
--- a/tests/gpuawarempi_osubenchmark_mvapich2.sh
+++ b/tests/gpuawarempi_osubenchmark_mvapich2.sh
@@ -33,6 +33,11 @@ ls -l ../build/libexec/osu-micro-benchmarks/mpi
 
 export HIP_VISIBLE_DEVICES=0,1
 
+# NOTE: since mvapich2 needs a hostfile to run on multiple nodes
+# this benchmark is run only on the local host unlike the openmpi
+# analog (i.e. gpuawarempi_osubenchmark_openmpi.sh) where we specify
+# -N 2 in the run command
+
 mpiexec -np 2  ../build/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bw -m 10240000
 
 cd ../..

--- a/tests/gpuawarempi_osubenchmark_mvapich2.sh
+++ b/tests/gpuawarempi_osubenchmark_mvapich2.sh
@@ -10,9 +10,7 @@ cd osu-micro-benchmarks-7.3
 
 module purge
 
-#module load rocm mvapich2/2.3.7 
-
-module load rocm
+module load rocm mvapich2/2.3.7 
 
 rm -rf build
 

--- a/tests/gpuawarempi_osubenchmark_mvapich2.sh
+++ b/tests/gpuawarempi_osubenchmark_mvapich2.sh
@@ -10,7 +10,9 @@ cd osu-micro-benchmarks-7.3
 
 module purge
 
-module load rocm mvapich2/2.3.7 
+#module load rocm mvapich2/2.3.7 
+
+module load rocm
 
 rm -rf build
 
@@ -31,7 +33,7 @@ ls -l ../build/libexec/osu-micro-benchmarks/mpi
 
 export HIP_VISIBLE_DEVICES=0,1
 
-mpirun -N 2 -n 2 -mca pml ucx ../build/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bw -m 10240000
+mpiexec -np 2  ../build/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_bw -m 10240000
 
 cd ../..
 


### PR DESCRIPTION
Using `mpiexec -np 2` instead of `mpirun -n 2 -N 2`