### PR TITLE
Stream overlap dev2

### DIFF
--- a/HIP/Stream_Overlap/1-async-copy-hw-queues/README.md
+++ b/HIP/Stream_Overlap/1-async-copy-hw-queues/README.md
@@ -8,8 +8,15 @@ cd build
 cmake ../
 make -j
 
-export GPU_MAX_HW_QUEUES=8 # for more than 4 streams
-./compute_comm_overlap <num-of-streams>
+1. Run baseline.
+   ./compute_comm_overlap <num-of-streams>
+
+2. Run with maximum HW queues per device.
+   export GPU_MAX_HW_QUEUES=8 # for more than 4 streams
+   ./compute_comm_overlap <num-of-streams>
+
+3. Run with larger block size.
+   ./compute_comm_overlap <num-of-streams> <block-size (optional, default:64)>
 ```
 
 ## Profile using Omnitrace (1.11.3)

--- a/HIP/Stream_Overlap/1-async-copy-hw-queues/compute_comm_overlap.hip
+++ b/HIP/Stream_Overlap/1-async-copy-hw-queues/compute_comm_overlap.hip
@@ -31,7 +31,7 @@ __global__ void cube(double *input, double *output,int offset, int elements_per_
  
 void usage()
 {
-  printf("Usage: ./compute_comm_overlap <nstreams>\n");
+  printf("Usage: ./compute_comm_overlap <nstreams> <blockSize (optional, default=64)>\n");
   exit(1);
   return;
 }
@@ -42,6 +42,11 @@ int main( int argc, char* argv[] )
     if (argc < 2)
       usage();
     int num_streams = atoi(argv[1]);
+
+    // Number of threads in each thread block
+    int blockSize = BLOCKDIM;
+    if (argc == 3)
+      blockSize = atoi(argv[2]);
 
     // Size of vectors
     int n = 100000000;
@@ -100,14 +105,8 @@ int main( int argc, char* argv[] )
         h_input1[i] = sin(i);
     }
 
-
-    int blockSize, gridSizePerStream;
-
-    // Number of threads in each thread block
-    blockSize = BLOCKDIM; //256;
-
     // Number of thread blocks in grid
-    gridSizePerStream = 104; //(int)ceil((float)elements_per_stream/blockSize);
+    int gridSizePerStream = 104; //(int)ceil((float)elements_per_stream/blockSize);
     printf("gridSizePerStream: %d\n", gridSizePerStream);
 
     hipEventRecord(start);


### PR DESCRIPTION
Updated stream overlap example to read in block size as a third (optional) argument. This example demonstrates large number of waves per stream further degrades overlapping streams even with GPU max HW queues env variable set.