### PR TITLE
Change DGEMM include and lin options to make them ROCm 6 compatible 

### DIFF
--- a/HIP/dgemm/CMakeLists.txt
+++ b/HIP/dgemm/CMakeLists.txt
@@ -9,7 +9,7 @@ project(xGEMM)
 set(CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
+set(CMAKE_EXE_LINKER_FLAGS "-lpthread")
 # -------------------------------------------------------------------------INCLUDES--
 include(GNUInstallDirs)
 # ------------------------------------------------------------------------------HIP--

--- a/HIP/dgemm/src/dgemm.cpp
+++ b/HIP/dgemm/src/dgemm.cpp
@@ -3,7 +3,7 @@
 ***************************************************************************/
 
 #include <hip/hip_runtime.h>
-#include <hipblas.h>
+#include <hipblas/hipblas.h>
 #include "dgemm.h"
 #include "darray.h"
 #include "timer.h"


### PR DESCRIPTION
DGEMM build requires pthreads and the `hipblas/` prefix to any HIPBLAS include.