### PR TITLE
Only print on the first validation failure

### DIFF
--- a/hipifly/vector_add/src/main.cpp
+++ b/hipifly/vector_add/src/main.cpp
@@ -71,7 +71,9 @@ int main( int argc, char *argv[] ){
   bool validation_passed = true;
   for ( int i=0; i<N; i++ ){
     if ( h_c[i] != ( h_a[i] + h_b[i] ) ){
-      printf( "ERROR: Result doesn't match expected value: %f   %f \n", h_c[i], h_a[i] + h_b[i] );
+      if(validation_passed){
+        printf( "ERROR: Result doesn't match expected value: %f   %f \n", h_c[i], h_a[i] + h_b[i] );
+      }
       validation_passed = false;
     }
   }


### PR DESCRIPTION
If this test fails cataclysmically this print statement can result in a log file many gigabytes in size. There may be more informative ways of handling this, but this PR is a start anyway.