### PR TITLE
roctracer and rocprofiler are now mutally exclusive

### DIFF
--- a/tests/tau_exec_check.sh
+++ b/tests/tau_exec_check.sh
@@ -70,7 +70,7 @@ rm -rf tautrace.0*
 make clean
 make
 
-mpirun -n 2 tau_exec -T rocm,ompt,openmp,rocprofiler,roctracer,pdt  ./Jacobi_hip -g 2 1
+mpirun -n 2 tau_exec -T rocm,ompt,openmp,roctracer,pdt  ./Jacobi_hip -g 2 1
 ls
 pprof
 


### PR DESCRIPTION
If an older tau installation still has both of these options, this invocation of tau_exec should still find it.