### PR TITLE
DiRAC/UCL OpenMP additional examples

### DIFF
--- a/HIP-OpenMP/F/daxpy/Makefile
+++ b/HIP-OpenMP/F/daxpy/Makefile
@@ -1,0 +1,34 @@
+EXECUTABLE = ./daxpy
+OBJECTS = daxpy_kernel.o hip_interface.o main.o
+
+all: $(EXECUTABLE) daxpy
+
+.PHONY: all clean
+
+ROCM_GPU ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+OPENMP_FLAGS = -fopenmp --offload-arch=${ROCM_GPU}
+
+FC_FLAGS = -g -O2 -fPIC ${OPENMP_FLAGS}
+HIPCC_FLAGS = -g -O2 -DNDEBUG -fPIC -I${ROCM_PATH}/include
+
+HIPCC ?= hipcc
+
+HIPCC_FLAGS += -munsafe-fp-atomics -D__DEVICE_CODE__
+LDFLAGS = ${OPENMP_FLAGS} -L${ROCM_PATH}/lib -lamdhip64 -lomptarget -lhiprtc
+
+
+main.o: main.F90 hip_interface.o
+	$(FC) $(FC_FLAGS) -c $^ -o $@
+
+hip_interface.o: hip_interface.F90
+	$(FC) $(FC_FLAGS) -c $^ -o $@
+
+daxpy_kernel.o: daxpy_kernel.cpp
+	$(HIPCC) $(HIPCC_FLAGS) -c $^ -o $@
+
+$(EXECUTABLE): $(OBJECTS)
+	$(FC) $(FC_FLAGS) $(OBJECTS) $(LDFLAGS) -o $@
+
+clean:
+	rm -f $(EXECUTABLE)
+	rm -f $(OBJECTS) *.mod

--- a/HIP-OpenMP/F/daxpy/daxpy_kernel.cpp
+++ b/HIP-OpenMP/F/daxpy/daxpy_kernel.cpp
@@ -1,0 +1,24 @@
+// daxpy_kernel.hip.cpp
+#include <hip/hip_runtime.h>
+#include <stdio.h>
+
+
+extern "C" {
+
+__global__ void daxpy_kernel(int n, double a, double * x, double * y) {
+   int i = threadIdx.x + blockIdx.x * blockDim.x;
+   y[i] = a * x[i] + y[i];
+   // for debug
+#ifdef DEBUG
+   printf("in kernel: y[%d]  is %g, a=%g, x[i]=%g \n", i, y[i], a, x[i]);
+#endif
+}
+
+void daxpy_hip(int n, double a, double * x, double * y) {
+   printf("daxpy_hip Compiled with DEVICE_CODE \n");
+   assert(n % 256 == 0);
+   daxpy_kernel<<<n/256,256,0,NULL>>>(n, a, x, y);
+   int ret=hipDeviceSynchronize();
+}
+
+}

--- a/HIP-OpenMP/F/daxpy/hip_interface.F90
+++ b/HIP-OpenMP/F/daxpy/hip_interface.F90
@@ -1,0 +1,14 @@
+module hip_interface
+  use iso_c_binding
+  implicit none
+
+  interface
+    subroutine daxpy_hip(n, a, x, y) bind(C)
+      import :: c_int, c_double, c_ptr
+      integer(c_int), value :: n
+      real(c_double), value :: a
+      type(c_ptr), value :: x, y
+    end subroutine daxpy_hip
+  end interface
+
+end module hip_interface

--- a/HIP-OpenMP/F/daxpy/main.F90
+++ b/HIP-OpenMP/F/daxpy/main.F90
@@ -1,0 +1,66 @@
+program daxpy
+  use iso_c_binding
+  use hip_interface
+  implicit none
+
+  integer, parameter :: n = 1024 ! use 1024 for our example
+  real(c_double) :: a = 2.0 ! use 2.0 for our example
+  real(c_double), allocatable, target :: x(:), y(:)
+  integer :: i
+
+  allocate(x(n), y(n))
+  print *, "daxpy Compiled with HOST_CODE"
+
+  ! allocate the device memory
+  !$omp target data map(to: x) map(tofrom: y)
+  call compute_1(n, x)
+  call compute_2(n, y)
+  !$omp target update to(x) to(y)
+
+  !$omp target data use_device_addr(x, y)
+  call daxpy_hip(n, a, c_loc(x), c_loc(y))
+  !$omp end target data
+
+  !$omp end target data
+
+  call compute_3(n, y)
+
+contains
+
+  subroutine compute_1(n, x)
+    integer, intent(in) :: n
+    real(c_double), dimension(n), intent(out) :: x
+    integer :: i
+    do i = 1, n
+       x(i) = 1.0_c_double
+    end do
+  end subroutine compute_1
+
+  subroutine compute_2(n, y)
+    integer, intent(in) :: n
+    real(c_double), dimension(n), intent(out) :: y
+    integer :: i
+    do i = 1, n
+       y(i) = 2.0_c_double
+    end do
+  end subroutine compute_2
+
+  subroutine compute_3(n, y)
+    integer, intent(in) :: n
+    real(c_double), dimension(n), intent(in) :: y
+    real(c_double) :: total
+    integer :: i
+
+    total = 0.0_c_double
+    do i = 1, n
+       total = total + y(i)
+    end do
+
+    if (total == (n * 4.0_c_double)) then
+       print *, "PASS: Results are verified as correct."
+    else
+       print *, "FAIL: Results are not correct. Expected ", n * 4.0_c_double, " and received ", total
+    end if
+  end subroutine compute_3
+
+end program daxpy

--- a/Pragma_Examples/OpenMP/C/SingleLineConstructs/Makefile
+++ b/Pragma_Examples/OpenMP/C/SingleLineConstructs/Makefile
@@ -1,4 +1,4 @@
-all: saxpy_cpu saxpy_gpu_singleunit_autoalloc saxpy_gpu_singleunit_dynamic saxpy_gpu_parallelfor saxpy_gpu_loop
+all: saxpy_cpu saxpy_gpu_singleunit_autoalloc saxpy_gpu_singleunit_dynamic saxpy_gpu_parallelfor saxpy_gpu_loop saxpy_gpu_collapse
 
 ROCM_GPU ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
 
@@ -39,6 +39,12 @@ saxpy_gpu_loop.o: saxpy_gpu_loop.c
 saxpy_gpu_loop: saxpy_gpu_loop.o
 	$(CC)  $(LDFLAGS)  ${OPENMP_OFFLOAD_FLAGS} $^ -o $@
 
+saxpy_gpu_collapse.o: saxpy_gpu_collapse.c
+	$(CC) $(CFLAGS) ${OPENMP_OFFLOAD_FLAGS} -c $<  -o $@
+
+saxpy_gpu_collapse: saxpy_gpu_collapse.o
+	$(CC)  $(LDFLAGS)  ${OPENMP_OFFLOAD_FLAGS} $^ -o $@
+
 clean:
 	rm -f saxpy_gpu_singleunit_autoalloc saxpy_gpu_singleunit_dynamic
-	rm -f saxpy_cpu saxpy_gpu_parallelfor saxpy_gpu_loop *.o
+	rm -f saxpy_cpu saxpy_gpu_parallelfor saxpy_gpu_loop saxpy_gpu_collapse *.o

--- a/Pragma_Examples/OpenMP/C/SingleLineConstructs/README.md
+++ b/Pragma_Examples/OpenMP/C/SingleLineConstructs/README.md
@@ -159,3 +159,30 @@ loop rather than worrying about where our array data is located.
 You can experiment with these examples on both a MI300A APU and a discrete GPU such as MI300X or MI200 series GPU. You
 should see a performance difference since the MI300A only has to map the pointer and not move the whole array.
 
+We have one less example to look at. Many scientific codes have multi-dimensional data that need to be operated on.
+We can use the collapse clause to spread out the work from both loops rather than just the outer one. This can
+be helpful if the outer loop is small. But since we are always trying to generate more work and parallelism, it
+can also have some benefit for larger outer loops.
+
+We'll consider the case of Fortran since 2-dimensional arrays are much easier to work with.
+The directive will now become
+
+```
+!$omp target teams distribute parallel do collapse(2)
+```
+
+Building and running the example
+
+```
+make saxpy_gpu_collapse
+./saxpy_gpu_collapse
+```
+
+And the output
+
+```
+Time of kernel: 0.007212
+check output:
+y[0][0] 4.000000
+y[N-1][M-1] 4.000000
+```

--- a/Pragma_Examples/OpenMP/C/SingleLineConstructs/saxpy_gpu_collapse.c
+++ b/Pragma_Examples/OpenMP/C/SingleLineConstructs/saxpy_gpu_collapse.c
@@ -1,0 +1,56 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <omp.h>
+
+void saxpy(float a, float **x, float **y, int M, int N) {
+   double tb, te;
+
+   tb = omp_get_wtime();
+   #pragma omp target teams distribute parallel for collapse(2)
+   for (int j = 0; j < N; j++) {
+      for (int i = 0; i < M; i++) {
+         y[j][i] += a * x[j][i];
+      }
+   }
+   te = omp_get_wtime();
+
+   printf("Time of kernel: %lf\n", te - tb);
+
+   printf("check output:\n");
+   printf("y[0][0] %lf\n",y[0][0]);
+   printf("y[N-1][M-1] %lf\n",y[N-1][M-1]);
+}
+
+float **malloc2D(int jmax, int imax)
+{
+   // first allocate a block of memory for the row pointers and the 2D array
+   float **x = (float **)malloc(jmax*sizeof(float *) + jmax*imax*sizeof(float));
+
+   // Now assign the start of the block of memory for the 2D array after the row pointers
+   x[0] = (float *)(x + jmax);
+
+   // Last, assign the memory location to point to for each row pointer
+   for (int j = 1; j < jmax; j++) {
+      x[j] = x[j-1] + imax;
+   }
+
+   return(x);
+}
+
+int main(int argc, char *argv[]){
+   int N=1000,M=1000;
+   float a=2.0f;
+
+   float **x = (float **)malloc2D(N,M);
+   float **y = (float **)malloc2D(N,M);
+
+   for (int j = 0; j < N; j++) {
+      for (int i = 0; i < M; i++) {
+         x[j][i] = 1.0f; y[j][i] = 2.0f;
+      }
+   }
+
+   saxpy(a, x, y, M, N);
+
+   free(x); free(y);
+}

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/0_member_function_portyourself/bigscience.cc
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/0_member_function_portyourself/bigscience.cc
@@ -19,6 +19,7 @@ int main(int argc, char *argv[]){
       myscienceclass.compute(&x[k], N);
    }
 
+   cout << "Last x value: " << x[N-1] << endl;
    delete[] x;
 
    cout << "Finished calculation" << endl;

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/1_member_function/bigscience.cc
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/1_member_function/bigscience.cc
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-//#pragma omp requires unified_shared_memory
+#pragma omp requires unified_shared_memory
 
 int main(int argc, char *argv[]){
 
@@ -22,6 +22,7 @@ int main(int argc, char *argv[]){
       myscienceclass.compute(&x[k], N);
    }
 
+   cout << "Last x value: " << x[N-1] << endl;
    delete[] x;
 
    cout << "Finished calculation" << endl;

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/2_member_function_map/Makefile
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/2_member_function_map/Makefile
@@ -1,0 +1,17 @@
+EXEC = bigscience
+default: ${EXEC}
+all: ${EXEC}
+
+ROCM_GPU ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+
+OPENMP_FLAGS = -fopenmp --offload-arch=$(ROCM_GPU)
+
+CXXFLAGS = -g -fstrict-aliasing ${OPENMP_FLAGS}
+LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
+
+${EXEC}: ${EXEC}.o
+	$(CXX) $(LDFLAGS) $^ -o $@
+
+# Cleanup
+clean:
+	rm -f *.o ${EXEC}

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/2_member_function_map/Science.hh
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/2_member_function_map/Science.hh
@@ -1,0 +1,10 @@
+class Science
+{
+
+public:
+   double init_value;
+
+   void compute(double *x, int N){
+      *x = 1.0;
+   }
+};

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/2_member_function_map/bigscience.cc
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/1_member_function/2_member_function_map/bigscience.cc
@@ -4,26 +4,24 @@
 
 #include <iostream>
 
-#include "HotScience.hh"
+#include "Science.hh"
 
 using namespace std;
 
-#pragma omp requires unified_shared_memory
-
 int main(int argc, char *argv[]){
 
-   HotScience myscienceclass;
+   Science myscienceclass;
 
    int N=10000;
    double *x = new double[N];
 
-#pragma omp target teams loop
+#pragma omp target teams loop map(from:x[0:N])
    for (int k = 0; k < N; k++){
       myscienceclass.compute(&x[k], N);
    }
-
-   cout << "Array value is " << x[0] << endl;
-   cout << "Finished calculation" << endl;
-
+    
+   cout << "Last x value: " << x[N-1] << endl;
    delete[] x;
+
+   cout << "Finished calculation" << endl;
 }

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/2_member_function_external/1_member_function_external/bigscience.cc
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/2_member_function_external/1_member_function_external/bigscience.cc
@@ -8,7 +8,7 @@
 
 using namespace std;
 
-//#pragma omp requires unified_shared_memory
+#pragma omp requires unified_shared_memory
 
 int main(int argc, char *argv[]){
 
@@ -22,6 +22,7 @@ int main(int argc, char *argv[]){
       myscienceclass.compute(&x[k], N);
    }
 
+   cout << "Last x value: " << x[N-1] << endl;
    delete[] x;
 
    cout << "Finished calculation" << endl;

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/2_member_function_external/2_member_function_external_data/Science_member_functions.cc
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/2_member_function_external/2_member_function_external_data/Science_member_functions.cc
@@ -2,6 +2,6 @@
 
 #pragma omp declare target
 void Science::compute(double *x, int N){
-   *x = Science::init_value;
+   *x = 1.0;
 }
 #pragma omp end declare target

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/2_member_function_external/2_member_function_external_data/bigscience.cc
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/2_member_function_external/2_member_function_external_data/bigscience.cc
@@ -8,8 +8,6 @@
 
 using namespace std;
 
-//#pragma omp requires unified_shared_memory
-
 int main(int argc, char *argv[]){
 
    Science myscienceclass;
@@ -17,11 +15,14 @@ int main(int argc, char *argv[]){
    int N=10000;
    double *x = new double[N];
 
+#pragma omp target enter data map (alloc:x[0:N])
 #pragma omp target teams loop
    for (int k = 0; k < N; k++){
       myscienceclass.compute(&x[k], N);
    }
-
+    
+#pragma omp target exit data map (from:x[0:N])
+   cout << "Last x value: " << x[N-1] << endl;
    delete[] x;
 
    cout << "Finished calculation" << endl;

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/HotScience.hh
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/HotScience.hh
@@ -1,0 +1,9 @@
+#include "Science.hh"
+
+class HotScience : public Science
+{
+
+public:
+    void compute(double *x, int N);
+
+};

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/HotScience_member_functions.cc
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/HotScience_member_functions.cc
@@ -1,0 +1,7 @@
+#include "HotScience.hh"
+
+#pragma omp declare target
+void HotScience::compute(double *x, int N){
+   *x = 5.0;
+}
+#pragma omp end declare target

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/Makefile
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/Makefile
@@ -1,0 +1,17 @@
+EXEC = bigscience
+default: ${EXEC}
+all: ${EXEC}
+
+ROCM_GPU ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+
+OPENMP_FLAGS = -fopenmp --offload-arch=$(ROCM_GPU)
+
+CXXFLAGS = -g -fstrict-aliasing -Wno-openmp-mapping ${OPENMP_FLAGS}
+LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
+
+${EXEC}: ${EXEC}.o HotScience_member_functions.o
+	$(CXX) $(LDFLAGS) $^ -o $@
+
+# Cleanup
+clean:
+	rm -f *.o ${EXEC}

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/Science.hh
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/Science.hh
@@ -1,0 +1,8 @@
+class Science
+{
+
+public:
+   double init_value;
+
+   virtual void compute(double *x, int N) { };
+};

--- a/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/bigscience.cc
+++ b/Pragma_Examples/OpenMP/CXX/5_device_routines/3_virtual_methods/2_virtual_methods_map/bigscience.cc
@@ -8,8 +8,6 @@
 
 using namespace std;
 
-#pragma omp requires unified_shared_memory
-
 int main(int argc, char *argv[]){
 
    HotScience myscienceclass;
@@ -17,7 +15,7 @@ int main(int argc, char *argv[]){
    int N=10000;
    double *x = new double[N];
 
-#pragma omp target teams loop
+#pragma omp target teams loop map(from:x[0:N])
    for (int k = 0; k < N; k++){
       myscienceclass.compute(&x[k], N);
    }

--- a/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/0_reduction_array_portyourself/Makefile
+++ b/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/0_reduction_array_portyourself/Makefile
@@ -1,0 +1,42 @@
+EXEC = reduction_array
+default: ${EXEC}
+all: ${EXEC}
+
+ROCM_GPU ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+
+FC1=$(notdir $(FC))
+
+ifneq ($(findstring amdflang,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp
+  FREE_FORM_FLAG = -ffree-form
+else ifneq ($(findstring flang,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp 
+  FREE_FORM_FLAG = -Mfreeform
+else ifneq ($(findstring gfortran,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp 
+  FREE_FORM_FLAG = -ffree-form
+else ifneq ($(findstring ftn,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp
+endif
+
+ifneq ($(findstring ftn,$(FC1)),)
+  FFLAGS = -g -eZ -O3 ${FREE_FORM_FLAG} ${OPENMP_FLAGS}
+else ifneq ($(findstring amdflang,$(FC1)),)
+  FFLAGS = -g -O3 ${FREE_FORM_FLAG} ${OPENMP_FLAGS}
+else
+  FFLAGS = -g -O3 ${FREE_FORM_FLAG} -fstrict-aliasing ${OPENMP_FLAGS}
+endif
+ifeq (${FC1},gfortran-13)
+   LDFLAGS = ${OPENMP_FLAGS} -fno-lto
+else ifneq ($(findstring ftn,$(FC1)),)
+   LDFLAGS = ${OPENMP_FLAGS} -L/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12
+else
+   LDFLAGS = ${OPENMP_FLAGS}
+endif
+
+${EXEC}: ${EXEC}.o
+	$(FC) $(LDFLAGS) $^ -o $@
+
+# Cleanup
+clean:
+	rm -f *.o ${EXEC} *.mod *.bin

--- a/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/0_reduction_array_portyourself/reduction_array.F
+++ b/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/0_reduction_array_portyourself/reduction_array.F
@@ -1,0 +1,21 @@
+! This program is based on a reproducer created by Mahdieh Ghazimirsaeed
+! Copyright (c) 2025 AMD HPC Application Performance Team
+! MIT License
+
+    program reduction
+    implicit none
+
+    integer, parameter :: real8 = kind(0.0d0)
+    real(real8) :: ce(2)
+    integer :: j
+
+    ce = 0.0_real8
+
+    do j = 1, 1000
+        ce(1) = ce(1) + 1.0_real8
+        ce(2) = ce(2) + 1.0_real8
+    end do
+
+    write(*,*) "ce(1) = ", ce(1), "ce(2) = ", ce(2)
+
+    end program reduction

--- a/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/1_reduction_array_soluiton/Makefile
+++ b/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/1_reduction_array_soluiton/Makefile
@@ -1,0 +1,42 @@
+EXEC = reduction_array
+default: ${EXEC}
+all: ${EXEC}
+
+ROCM_GPU ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+
+FC1=$(notdir $(FC))
+
+ifneq ($(findstring amdflang,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp --offload-arch=$(ROCM_GPU)
+  FREE_FORM_FLAG = -ffree-form
+else ifneq ($(findstring flang,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp --offload-arch=$(ROCM_GPU)
+  FREE_FORM_FLAG = -Mfreeform
+else ifneq ($(findstring gfortran,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp --offload=-march=$(ROCM_GPU)
+  FREE_FORM_FLAG = -ffree-form
+else ifneq ($(findstring ftn,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp
+endif
+
+ifneq ($(findstring ftn,$(FC1)),)
+  FFLAGS = -g -eZ -O3 ${FREE_FORM_FLAG} ${OPENMP_FLAGS}
+else ifneq ($(findstring amdflang,$(FC1)),)
+  FFLAGS = -g -O3 ${FREE_FORM_FLAG} ${OPENMP_FLAGS}
+else
+  FFLAGS = -g -O3 ${FREE_FORM_FLAG} -fstrict-aliasing ${OPENMP_FLAGS}
+endif
+ifeq (${FC1},gfortran-13)
+   LDFLAGS = ${OPENMP_FLAGS} -fno-lto
+else ifneq ($(findstring ftn,$(FC1)),)
+   LDFLAGS = ${OPENMP_FLAGS} -L/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12
+else
+   LDFLAGS = ${OPENMP_FLAGS}
+endif
+
+${EXEC}: ${EXEC}.o
+	$(FC) $(FFLAGS) $(LDFLAGS) $^ -o $@
+
+# Cleanup
+clean:
+	rm -f *.o ${EXEC} *.mod *.bin

--- a/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/1_reduction_array_soluiton/reduction_array.F
+++ b/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/1_reduction_array_soluiton/reduction_array.F
@@ -1,0 +1,23 @@
+! This program is based on a reproducer created by Mahdieh Ghazimirsaeed
+! Copyright (c) 2025 AMD HPC Application Performance Team
+! MIT License
+
+    program reduction
+    implicit none
+
+    integer, parameter :: real8 = kind(0.0d0)
+    real(real8) :: ce(2)
+    integer :: j
+
+    ce = 0.0_real8
+
+    !$omp target teams distribute parallel do reduction(+:ce(1), ce(2))
+    do j = 1, 1000
+        ce(1) = ce(1) + 1.0_real8
+        ce(2) = ce(2) + 1.0_real8
+    end do
+    !$omp end target teams distribute parallel do
+
+    write(*,*) "ce(1) = ", ce(1), "ce(2) = ", ce(2)
+
+    end program reduction

--- a/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/README.md
+++ b/Pragma_Examples/OpenMP/Fortran/9_reduction_array-not_working/README.md
@@ -1,0 +1,21 @@
+# Porting excercise reduction of multiple scalars in one kernel
+
+README.md from `HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/9_reduction_array` from the Training Examples repository.
+
+This folder has two code versions:
+
+0) a serial cpu version to port yourself. 
+
+Hint: don't forget to port the Makefile.
+
+Build:
+```
+make
+````
+Run:
+```
+./reduction_scalar
+```
+
+1) an openmp offload ported solution. 
+The solution shows how you can do a reduction of multiple values into an array in one kernel.

--- a/Pragma_Examples/OpenMP/Fortran/Atomic/Makefile
+++ b/Pragma_Examples/OpenMP/Fortran/Atomic/Makefile
@@ -1,0 +1,42 @@
+EXEC = atomic
+default: ${EXEC}
+all: ${EXEC}
+
+ROCM_GPU ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+
+FC1=$(notdir $(FC))
+
+ifneq ($(findstring amdflang,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp --offload-arch=$(ROCM_GPU)
+  FREE_FORM_FLAG = -ffree-form
+else ifneq ($(findstring flang,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp --offload-arch=$(ROCM_GPU)
+  FREE_FORM_FLAG = -Mfreeform
+else ifneq ($(findstring gfortran,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp --offload=-march=$(ROCM_GPU)
+  FREE_FORM_FLAG = -ffree-form
+else ifneq ($(findstring ftn,$(FC1)),)
+  OPENMP_FLAGS = -fopenmp
+endif
+
+ifneq ($(findstring ftn,$(FC1)),)
+  FFLAGS = -g -eZ -O3 ${FREE_FORM_FLAG} ${OPENMP_FLAGS}
+else ifneq ($(findstring amdflang,$(FC1)),)
+  FFLAGS = -g -O3 ${FREE_FORM_FLAG} ${OPENMP_FLAGS}
+else
+  FFLAGS = -g -O3 ${FREE_FORM_FLAG} -fstrict-aliasing ${OPENMP_FLAGS}
+endif
+ifeq (${FC1},gfortran-13)
+   LDFLAGS = ${OPENMP_FLAGS} -fno-lto
+else ifneq ($(findstring ftn,$(FC1)),)
+   LDFLAGS = ${OPENMP_FLAGS} -L/opt/rh/gcc-toolset-12/root/usr/lib/gcc/x86_64-redhat-linux/12
+else
+   LDFLAGS = ${OPENMP_FLAGS}
+endif
+
+${EXEC}: ${EXEC}.o
+	$(FC) $(FFLAGS) $(LDFLAGS) $^ -o $@
+
+# Cleanup
+clean:
+	rm -f *.o ${EXEC} *.mod *.bin

--- a/Pragma_Examples/OpenMP/Fortran/Atomic/atomic.F
+++ b/Pragma_Examples/OpenMP/Fortran/Atomic/atomic.F
@@ -1,0 +1,42 @@
+! This program is based on a reproducer created by Mahdieh Ghazimirsaeed
+! Copyright (c) 2025 AMD HPC Application Performance Team
+! MIT License
+
+program atomic_vs_reduction
+  use omp_lib
+  implicit none
+
+  integer, parameter :: real8 = kind(0.0d0)
+  integer, parameter :: N = 10000
+  real(real8) :: a(N)
+  real(real8) :: sum_of_a, tstart
+  integer :: i
+
+  !$omp requires unified_shared_memory
+
+  !$omp target teams distribute parallel do
+  do i = 1, N
+     a(i) = 1.0_real8
+  end do
+  !$omp end target teams distribute parallel do
+
+  sum_of_a = 0.0_real8
+  tstart = omp_get_wtime()
+  !$omp target teams distribute parallel do map(tofrom:sum_of_a)
+  do i = 1, N
+     !$omp atomic
+     sum_of_a = sum_of_a + a(i)
+  end do
+  !$omp end target teams distribute parallel do
+  print *, '   Atomic result: ', sum_of_a, ' Runtime is: ', omp_get_wtime() - tstart, ' secs'
+
+  sum_of_a = 0.0_real8
+  tstart = omp_get_wtime()
+  !$omp target teams distribute parallel do reduction(+:sum_of_a)
+  do i = 1, N
+     sum_of_a = sum_of_a + a(i)
+  end do
+  !$omp end target teams distribute parallel do
+  print *, 'Reduction result: ', sum_of_a, ' Runtime is: ', omp_get_wtime() - tstart, ' secs'
+
+end program atomic_vs_reduction

--- a/Pragma_Examples/OpenMP/Fortran/memory_pragmas/CMakeLists.txt
+++ b/Pragma_Examples/OpenMP/Fortran/memory_pragmas/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
+project(Memory_pragmas LANGUAGES Fortran)
+
+if (NOT CMAKE_BUILD_TYPE)
+   set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif(NOT CMAKE_BUILD_TYPE)
+
+execute_process(COMMAND rocminfo COMMAND grep -m 1 -E gfx[^0]{1} COMMAND sed -e "s/ *Name: *//" OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE ROCM_GPU)
+
+string(REPLACE "-O2" "-O3" CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO}")
+set(CMAKE_Fortran_FLAGS_DEBUG "-ggdb")
+set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fopenmp --offload-arch=${ROCM_GPU}")
+
+message(${CMAKE_Fortran_COMPILER_ID})
+if ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Clang")
+   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fopenmp --offload-arch=${ROCM_GPU}")
+elseif ("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fopenmp -foffload=-march=${ROCM_GPU}")
+elseif (CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
+   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fopenmp")
+   #the cray compiler decides the offload-arch by loading appropriate modules
+   #module load craype-accel-amd-gfx942 for example
+endif()
+
+add_executable(mem1 mem1.F90)
+add_executable(mem2 mem2.F90)
+add_executable(mem3 mem3.F90)
+add_executable(mem4 mem4.F90)
+add_executable(mem5 mem5.F90)
+add_executable(mem7 mem7.F90)
+add_executable(mem8 mem8.F90)
+
+install(TARGETS mem1 mem2 mem3 mem4 mem5 mem7 mem8)

--- a/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem1.F90
+++ b/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem1.F90
@@ -1,0 +1,80 @@
+! Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+program main
+  use omp_lib
+  implicit none
+  integer, parameter :: NTIMERS = 1
+  integer :: num_iteration, n, i, iter
+  real(8) :: main_timer, main_start, start
+  real(8) :: sum_time, max_time, min_time, avg_time
+  real(8), allocatable :: timers(:)
+  real(8), allocatable :: x(:), y(:), z(:)
+  real(8) :: a
+
+  num_iteration = NTIMERS
+  n = 100000
+  main_start = omp_get_wtime()
+  a = 3.0d0
+
+  allocate(x(n), y(n), z(n), timers(num_iteration))
+
+  do i = 1, n
+    x(i) = 2.0d0
+    y(i) = 1.0d0
+  end do
+
+  do iter = 1, num_iteration
+    start = omp_get_wtime()
+    call daxpy(n, a, x, y, z)
+    timers(iter) = omp_get_wtime() - start
+  end do
+
+  max_time = -1.0d10
+  min_time =  1.0d10
+  sum_time =  0.0d0
+
+  sum_time = sum(timers)
+  max_time = maxval(timers)
+  min_time = minval(timers)
+  avg_time = sum_time / dble(num_iteration)
+
+  print '(A,F9.6,A,F9.6,A,F9.6)', "-Timing in Seconds: min=", min_time, ", max=", max_time, ", avg=", avg_time
+  main_timer = omp_get_wtime() - main_start
+  print '(A,F9.5)', "-Overall time is ", main_timer
+  print "(A, I0, A, F0.5)", "Last Value: z(", n, ")=", z(n)
+
+  deallocate(x, y, z, timers)
+
+contains
+
+  subroutine daxpy(n, a, x, y, z)
+    implicit none
+    integer, intent(in) :: n
+    real(8), intent(in) :: a
+    real(8), intent(in) :: x(n), y(n)
+    real(8), intent(out) :: z(n)
+    integer :: i
+    !$omp target teams distribute parallel do map(to: x, y) map(from: z)
+    do i = 1, n
+      z(i) = a * x(i) + y(i)
+    end do
+  end subroutine daxpy
+
+end program main

--- a/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem2.F90
+++ b/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem2.F90
@@ -1,0 +1,84 @@
+! Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+program main
+  use omp_lib
+  implicit none
+  integer, parameter :: NTIMERS = 1
+  integer :: num_iteration, n, i, iter
+  real(8) :: main_timer, main_start, start
+  real(8) :: sum_time, max_time, min_time, avg_time
+  real(8), allocatable :: timers(:)
+  real(8), allocatable :: x(:), y(:), z(:)
+  real(8) :: a
+
+  num_iteration = NTIMERS
+  n = 100000
+  main_start = omp_get_wtime()
+  a = 3.0d0
+
+  allocate(x(n), y(n), z(n), timers(num_iteration))
+
+  do i = 1, n
+    x(i) = 2.0d0
+    y(i) = 1.0d0
+  end do
+
+  !$omp target enter data map(alloc: x, y, z)
+
+  do iter = 1, num_iteration
+    start = omp_get_wtime()
+    call daxpy(n, a, x, y, z)
+    timers(iter) = omp_get_wtime() - start
+  end do
+
+  max_time = -1.0d10
+  min_time =  1.0d10
+  sum_time =  0.0d0
+
+  sum_time = sum(timers)
+  max_time = maxval(timers)
+  min_time = minval(timers)
+  avg_time = sum_time / dble(num_iteration)
+
+  print '(A,F9.6,A,F9.6,A,F9.6)', "-Timing in Seconds: min=", min_time, ", max=", max_time, ", avg=", avg_time
+  main_timer = omp_get_wtime() - main_start
+  print '(A,F9.5)', "-Overall time is ", main_timer
+  print "(A, I0, A, F0.5)", "Last Value: z(", n, ")=", z(n)
+
+  !$omp target exit data map(delete: x, y, z)
+
+  deallocate(x, y, z, timers)
+
+contains
+
+  subroutine daxpy(n, a, x, y, z)
+    implicit none
+    integer, intent(in) :: n
+    real(8), intent(in) :: a
+    real(8), intent(in) :: x(n), y(n)
+    real(8), intent(out) :: z(n)
+    integer :: i
+    !$omp target teams distribute parallel do map(always, to: x, y) map(always, from: z)
+    do i = 1, n
+      z(i) = a * x(i) + y(i)
+    end do
+  end subroutine daxpy
+
+end program main

--- a/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem3.F90
+++ b/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem3.F90
@@ -1,0 +1,87 @@
+! Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+program main
+  use omp_lib
+  implicit none
+  integer, parameter :: NTIMERS = 1
+  integer :: num_iteration, n, i, iter
+  real(8) :: main_timer, main_start, start
+  real(8) :: sum_time, max_time, min_time, avg_time
+  real(8), allocatable :: timers(:)
+  real(8), allocatable :: x(:), y(:), z(:)
+  real(8) :: a
+
+  num_iteration = NTIMERS
+  n = 100000
+  main_start = omp_get_wtime()
+  a = 3.0d0
+
+  allocate(x(n), y(n), z(n), timers(num_iteration))
+
+  do i = 1, n
+    x(i) = 2.0d0
+    y(i) = 1.0d0
+  end do
+
+  !$omp target enter data map(alloc: x, y, z)
+
+  do iter = 1, num_iteration
+    start = omp_get_wtime()
+    call daxpy(n, a, x, y, z)
+    timers(iter) = omp_get_wtime() - start
+  end do
+
+  max_time = -1.0d10
+  min_time =  1.0d10
+  sum_time =  0.0d0
+
+  sum_time = sum(timers)
+  max_time = maxval(timers)
+  min_time = minval(timers)
+  avg_time = sum_time / dble(num_iteration)
+
+  print '(A,F9.6,A,F9.6,A,F9.6)', "-Timing in Seconds: min=", min_time, ", max=", max_time, ", avg=", avg_time
+  main_timer = omp_get_wtime() - main_start
+  print '(A,F9.5)', "-Overall time is ", main_timer
+  print "(A, I0, A, F0.5)", "Last Value: z(", n, ")=", z(n)
+
+  !$omp target exit data map(delete: x, y, z)
+
+  deallocate(x, y, z, timers)
+
+contains
+
+  subroutine daxpy(n, a, x, y, z)
+    implicit none
+    integer, intent(in) :: n
+    real(8), intent(in) :: a
+    real(8), intent(in) :: x(n), y(n)
+    real(8), intent(out) :: z(n)
+    integer :: i
+
+    !$omp target update to(x, y)
+    !$omp target teams distribute parallel do
+    do i = 1, n
+      z(i) = a * x(i) + y(i)
+    end do
+    !$omp target update from(z)
+  end subroutine daxpy
+
+end program main

--- a/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem4.F90
+++ b/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem4.F90
@@ -1,0 +1,84 @@
+! Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+program main
+  use omp_lib
+  implicit none
+  integer, parameter :: NTIMERS = 1
+  integer :: num_iteration, n, i, iter
+  real(8) :: main_timer, main_start, start
+  real(8) :: sum_time, max_time, min_time, avg_time
+  real(8), allocatable :: timers(:)
+  real(8), allocatable :: x(:), y(:), z(:)
+  real(8) :: a
+
+  num_iteration = NTIMERS
+  n = 100000
+  main_start = omp_get_wtime()
+  a = 3.0d0
+
+  allocate(x(n), y(n), z(n), timers(num_iteration))
+
+  do i = 1, n
+    x(i) = 2.0d0
+    y(i) = 1.0d0
+  end do
+
+  !$omp target enter data map(alloc: x, y, z)
+
+  do iter = 1, num_iteration
+    start = omp_get_wtime()
+    call daxpy(n, a, x, y, z)
+    timers(iter) = omp_get_wtime() - start
+  end do
+
+  max_time = -1.0d10
+  min_time =  1.0d10
+  sum_time =  0.0d0
+
+  sum_time = sum(timers)
+  max_time = maxval(timers)
+  min_time = minval(timers)
+  avg_time = sum_time / dble(num_iteration)
+
+  print '(A,F9.6,A,F9.6,A,F9.6)', "-Timing in Seconds: min=", min_time, ", max=", max_time, ", avg=", avg_time
+  main_timer = omp_get_wtime() - main_start
+  print '(A,F9.5)', "-Overall time is ", main_timer
+  print "(A, I0, A, F0.5)", "Last Value: z(", n, ")=", z(n)
+
+  !$omp target exit data map(release: x, y, z)
+
+  deallocate(x, y, z, timers)
+
+contains
+
+  subroutine daxpy(n, a, x, y, z)
+    implicit none
+    integer, intent(in) :: n
+    real(8), intent(in) :: a
+    real(8), intent(in) :: x(n), y(n)
+    real(8), intent(out) :: z(n)
+    integer :: i
+    !$omp target teams distribute parallel do map(always, to: x, y) map(always, from: z)
+    do i = 1, n
+      z(i) = a * x(i) + y(i)
+    end do
+  end subroutine daxpy
+
+end program main

--- a/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem5.F90
+++ b/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem5.F90
@@ -1,0 +1,85 @@
+! Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+program main
+  use omp_lib
+  implicit none
+  integer, parameter :: NTIMERS = 1
+  integer :: num_iteration, n, i, iter
+  real(8) :: main_timer, main_start, start
+  real(8) :: sum_time, max_time, min_time, avg_time
+  real(8), allocatable :: timers(:)
+  real(8), allocatable :: x(:), y(:), z(:)
+  real(8) :: a
+
+  num_iteration = NTIMERS
+  n = 100000
+  main_start = omp_get_wtime()
+  a = 3.0d0
+
+  allocate(x(n), y(n), z(n), timers(num_iteration))
+
+  do i = 1, n
+    x(i) = 2.0d0
+    y(i) = 1.0d0
+  end do
+
+  !$omp target enter data map(to: x, y) map(alloc: z)
+
+  do iter = 1, num_iteration
+    start = omp_get_wtime()
+    call daxpy(n, a, x, y, z)
+    timers(iter) = omp_get_wtime() - start
+  end do
+
+  max_time = -1.0d10
+  min_time =  1.0d10
+  sum_time =  0.0d0
+
+  sum_time = sum(timers)
+  max_time = maxval(timers)
+  min_time = minval(timers)
+  avg_time = sum_time / dble(num_iteration)
+
+  print '(A,F9.6,A,F9.6,A,F9.6)', "-Timing in Seconds: min=", min_time, ", max=", max_time, ", avg=", avg_time
+  main_timer = omp_get_wtime() - main_start
+  print '(A,F9.5)', "-Overall time is ", main_timer
+
+  !$omp target exit data map(from: z) map(delete: x, y)
+  
+  print "(A, I0, A, F0.5)", "Last Value: z(", n, ")=", z(n)
+
+  deallocate(x, y, z, timers)
+
+contains
+
+  subroutine daxpy(n, a, x, y, z)
+    implicit none
+    integer, intent(in) :: n
+    real(8), intent(in) :: a
+    real(8), intent(in) :: x(n), y(n)
+    real(8), intent(out) :: z(n)
+    integer :: i
+    !$omp target teams distribute parallel do map(to: x, y) map(from: z)
+    do i = 1, n
+      z(i) = a * x(i) + y(i)
+    end do
+  end subroutine daxpy
+
+end program main

--- a/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem7.F90
+++ b/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem7.F90
@@ -1,0 +1,84 @@
+! Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+program main
+  use omp_lib
+  implicit none
+
+  !$omp requires unified_shared_memory
+  
+  integer, parameter :: NTIMERS = 1
+  integer :: num_iteration, n, i, iter
+  real(8) :: main_timer, main_start, start
+  real(8) :: sum_time, max_time, min_time, avg_time
+  real(8), allocatable :: timers(:)
+  real(8), allocatable :: x(:), y(:), z(:)
+  real(8) :: a
+
+  num_iteration = NTIMERS
+  n = 100000
+  main_start = omp_get_wtime()
+  a = 3.0d0
+
+  allocate(x(n), y(n), z(n), timers(num_iteration))
+
+  !$omp target teams distribute parallel do
+  do i = 1, n
+    x(i) = 2.0d0
+    y(i) = 1.0d0
+  end do
+
+  do iter = 1, num_iteration
+    start = omp_get_wtime()
+    call daxpy(n, a, x, y, z)
+    timers(iter) = omp_get_wtime() - start
+  end do
+
+  max_time = -1.0d10
+  min_time =  1.0d10
+  sum_time =  0.0d0
+
+  sum_time = sum(timers)
+  max_time = maxval(timers)
+  min_time = minval(timers)
+  avg_time = sum_time / dble(num_iteration)
+
+  print '(A,F9.6,A,F9.6,A,F9.6)', "-Timing in Seconds: min=", min_time, ", max=", max_time, ", avg=", avg_time
+  main_timer = omp_get_wtime() - main_start
+  print '(A,F9.5)', "-Overall time is ", main_timer
+  print "(A, I0, A, F0.5)", "Last Value: z(", n, ")=", z(n)
+
+  deallocate(x, y, z, timers)
+
+contains
+
+  subroutine daxpy(n, a, x, y, z)
+    implicit none
+    integer, intent(in) :: n
+    real(8), intent(in) :: a
+    real(8), intent(in) :: x(n), y(n)
+    real(8), intent(out) :: z(n)
+    integer :: i
+    !$omp target teams distribute parallel do
+    do i = 1, n
+      z(i) = a * x(i) + y(i)
+    end do
+  end subroutine daxpy
+
+end program main

--- a/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem8.F90
+++ b/Pragma_Examples/OpenMP/Fortran/memory_pragmas/mem8.F90
@@ -1,0 +1,90 @@
+! Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+
+! The above copyright notice and this permission notice shall be included in
+! all copies or substantial portions of the Software.
+
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+! THE SOFTWARE.
+program main
+  use omp_lib
+  implicit none
+  
+  #ifndef NO_UNIFIED_SHARED_MEMORY
+  !$omp requires unified_shared_memory
+  #endif
+  
+  integer, parameter :: NTIMERS = 1
+  integer :: num_iteration, n, i, iter
+  real(8) :: main_timer, main_start, start
+  real(8) :: sum_time, max_time, min_time, avg_time
+  real(8), allocatable :: timers(:)
+  real(8), allocatable :: x(:), y(:), z(:)
+  real(8) :: a
+
+  num_iteration = NTIMERS
+  n = 100000
+  main_start = omp_get_wtime()
+  a = 3.0d0
+
+  allocate(x(n), y(n), z(n), timers(num_iteration))
+  !$omp target enter data map(alloc: x, y, z)
+
+  !$omp target teams distribute parallel do
+  do i = 1, n
+    x(i) = 2.0d0
+    y(i) = 1.0d0
+  end do
+
+  do iter = 1, num_iteration
+    start = omp_get_wtime()
+    call daxpy(n, a, x, y, z)
+    timers(iter) = omp_get_wtime() - start
+  end do
+
+  max_time = -1.0d10
+  min_time =  1.0d10
+  sum_time =  0.0d0
+
+  sum_time = sum(timers)
+  max_time = maxval(timers)
+  min_time = minval(timers)
+  avg_time = sum_time / dble(num_iteration)
+
+  print '(A,F9.6,A,F9.6,A,F9.6)', "-Timing in Seconds: min=", min_time, ", max=", max_time, ", avg=", avg_time
+  main_timer = omp_get_wtime() - main_start
+  print '(A,F9.5)', "-Overall time is ", main_timer
+
+  !$omp target update from(z)
+  print "(A, I0, A, F0.5)", "Last Value: z(", n, ")=", z(n)
+
+  !$omp target exit data map(delete: x, y, z)
+  deallocate(x, y, z, timers)
+
+contains
+
+  subroutine daxpy(n, a, x, y, z)
+    implicit none
+    integer, intent(in) :: n
+    real(8), intent(in) :: a
+    real(8), intent(in) :: x(n), y(n)
+    real(8), intent(out) :: z(n)
+    integer :: i
+    !$omp target teams distribute parallel do
+    do i = 1, n
+      z(i) = a * x(i) + y(i)
+    end do
+  end subroutine daxpy
+
+end program main

--- a/Pragma_Examples/OpenMP/Intro/Fortran_examples/Makefile
+++ b/Pragma_Examples/OpenMP/Intro/Fortran_examples/Makefile
@@ -1,0 +1,30 @@
+all:target_data_structured target_data_unstructured target_data_update
+
+ROCM_GPU ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+
+OPENMP_FLAGS = -fopenmp
+OPENMP_OFFLOAD_FLAGS = -fopenmp --offload-arch=${ROCM_GPU}
+
+FFLAGS = -g -O3 ${FREE_FORM_FLAG}
+
+target_data_structured.o: target_data_structured.F90
+	$(FC) -c $(FFLAGS) ${OPENMP_FLAGS} $^
+
+target_data_structured: target_data_structured.o
+	$(FC) $(LDFLAGS) ${OPENMP_FLAGS} $^ -o $@
+
+target_data_unstructured.o: target_data_unstructured.F90
+	$(FC) -c $(FFLAGS) ${OPENMP_FLAGS} $^
+
+target_data_unstructured: target_data_unstructured.o
+	$(FC) $(LDFLAGS) ${OPENMP_FLAGS} $^ -o $@
+
+target_data_update.o: target_data_update.F90
+	$(FC) -c $(FFLAGS) ${OPENMP_FLAGS} $^
+
+target_data_update: target_data_update.o
+	$(FC) $(LDFLAGS) ${OPENMP_FLAGS} $^ -o $@
+
+# Cleanup
+clean:
+	rm -f *.o  *.mod target_data_structured target_data_unstructured target_data_update

--- a/Pragma_Examples/OpenMP/Intro/Fortran_examples/target_data_structured.F90
+++ b/Pragma_Examples/OpenMP/Intro/Fortran_examples/target_data_structured.F90
@@ -1,0 +1,64 @@
+program main
+  implicit none
+  call example()
+contains
+
+  subroutine example()
+    implicit none
+    integer, parameter :: N = 100000
+    real(4) :: tmp(N), a(N), b(N), c(N)
+
+    !$omp target data map(alloc:tmp) &
+    !$omp                map(to:a, b) &
+    !$omp                map(tofrom:c)
+    call zeros(tmp, N)
+    call compute_kernel_1(tmp, a, N) ! Uses target
+    call saxpy(2.0, tmp, b, N)
+    call compute_kernel_2(tmp, b, N) ! Uses target
+    call saxpy(2.0, c, tmp, N)
+    !$omp end target data
+
+    print *, "Example program for structured target data region completed successfully"
+  end subroutine example
+
+  subroutine zeros(a, n)
+    implicit none
+    integer, intent(in) :: n
+    real(4), intent(out) :: a(n)
+    integer :: i
+    !$omp target teams distribute parallel do
+    do i = 1, n
+      a(i) = 0.0
+    end do
+  end subroutine zeros
+
+  subroutine saxpy(a, y, x, n)
+    implicit none
+    integer, intent(in) :: n
+    real(4), intent(in) :: a
+    real(4), intent(inout) :: y(n)
+    real(4), intent(in) :: x(n)
+    integer :: i
+    !$omp target teams distribute parallel do
+    do i = 1, n
+      y(i) = a * x(i) + y(i)
+    end do
+  end subroutine saxpy
+
+  subroutine compute_kernel_1(x, y, n)
+    implicit none
+    integer, intent(in) :: n
+    real(4), intent(inout) :: x(n)
+    real(4), intent(in) :: y(n)
+    ! Placeholder for OpenMP target computations
+  end subroutine compute_kernel_1
+
+  subroutine compute_kernel_2(x, y, n)
+    implicit none
+    integer, intent(in) :: n
+    real(4), intent(inout) :: x(n)
+    real(4), intent(in) :: y(n)
+    ! Placeholder for OpenMP target computations
+  end subroutine compute_kernel_2
+
+end program main

--- a/Pragma_Examples/OpenMP/Intro/Fortran_examples/target_data_unstructured.F90
+++ b/Pragma_Examples/OpenMP/Intro/Fortran_examples/target_data_unstructured.F90
@@ -1,0 +1,67 @@
+program main
+  implicit none
+  integer, parameter :: N = 100000
+  real(4), allocatable :: tmp(:), a(:), b(:), c(:)
+
+  allocate(tmp(N), a(N), b(N), c(N))
+  
+  !$omp target enter data map(alloc:tmp, a, b, c)
+  call compute(N)
+  !$omp target exit data map(delete:tmp, a, b, c)
+
+  deallocate(tmp, a, b, c)
+  print *, "Example program for unstructured target data region completed successfully"
+
+contains
+
+  subroutine compute(N)
+    implicit none
+    integer, intent(in) :: N
+    call zeros(tmp, N)
+    call compute_kernel_1(tmp, a, N) ! Uses target
+    call saxpy(2.0, tmp, b, N)
+    call compute_kernel_2(tmp, b, N) ! Uses target
+    call saxpy(2.0, c, tmp, N)
+  end subroutine compute
+
+  subroutine zeros(a, n)
+    implicit none
+    integer, intent(in) :: n
+    real(4), intent(out) :: a(n)
+    integer :: i
+    !$omp target teams distribute parallel do
+    do i = 1, n
+      a(i) = 0.0
+    end do
+  end subroutine zeros
+
+  subroutine saxpy(a, y, x, n)
+    implicit none
+    integer, intent(in) :: n
+    real(4), intent(in) :: a
+    real(4), intent(inout) :: y(n)
+    real(4), intent(in) :: x(n)
+    integer :: i
+    !$omp target teams distribute parallel do
+    do i = 1, n
+      y(i) = a * x(i) + y(i)
+    end do
+  end subroutine saxpy
+
+  subroutine compute_kernel_1(x, y, n)
+    implicit none
+    integer, intent(in) :: n
+    real(4), intent(inout) :: x(n)
+    real(4), intent(in) :: y(n)
+    ! Placeholder for OpenMP target computations
+  end subroutine compute_kernel_1
+
+  subroutine compute_kernel_2(x, y, n)
+    implicit none
+    integer, intent(in) :: n
+    real(4), intent(inout) :: x(n)
+    real(4), intent(in) :: y(n)
+    ! Placeholder for OpenMP target computations
+  end subroutine compute_kernel_2
+
+end program main

--- a/Pragma_Examples/OpenMP/Intro/Fortran_examples/target_data_update.F90
+++ b/Pragma_Examples/OpenMP/Intro/Fortran_examples/target_data_update.F90
@@ -1,0 +1,71 @@
+module computation_module
+  contains
+
+  function some_computation(x) result(r)
+    implicit none
+    double precision, intent(in) :: x
+    double precision :: r
+    r = 2.0d0 * x
+  end function some_computation
+
+  function final_computation(x, y) result(r)
+    implicit none
+    double precision, intent(in) :: x, y
+    double precision :: r
+    r = x + y
+  end function final_computation
+
+end module computation_module
+
+module update_module
+  contains
+
+  subroutine update_input_array_on_the_host(x, N)
+    implicit none
+    integer, intent(in) :: N
+    double precision, intent(inout) :: x(N)
+    integer :: i
+    do i = 1, N
+       x(i) = 2.0d0
+    end do
+  end subroutine update_input_array_on_the_host
+
+end module update_module
+
+program main
+  use computation_module
+  use update_module
+  implicit none
+
+  integer, parameter :: N = 1000000
+  real(8), allocatable :: input(:), tmp(:)
+  real(8) :: res
+  integer :: i
+
+  allocate(tmp(N), input(N))
+  input = 1.0d0
+  res = 0.0d0
+
+  !$omp target data map(alloc: tmp) map(to: input) map(tofrom: res)
+
+  !$omp target teams distribute parallel do
+  do i = 1, N
+     tmp(i) = some_computation(input(i))
+  end do
+
+  call update_input_array_on_the_host(input, N)
+
+  !$omp target update to(input)
+  
+  !$omp target teams distribute parallel do reduction(+:res)
+  do i = 1, N
+    res = res + final_computation(input(i), tmp(i))
+  end do
+
+  !$omp end target data
+
+  print *, "Final result:", res
+
+  deallocate(tmp, input)
+
+end program main


### PR DESCRIPTION
This PR includes all contributions (working or not) of additional and/or modified examples  created for DiRAC AMD GPU training by UCL.

Most of the contributions here are Fortran versions of existing C/CXX examples.  Several directories / examples are missing accompanying README.md (or not sufficiently updated them), or might not be complete with all examples in the corresponding C/CXX directory as they were not part of the DiRAC training materials.

Some iterations with the mainterns might be required to ensure the additions are complete and aligned with all the existing content. 