### PR TITLE
Update C++ jacobi example to use C++ compiler

### DIFF
--- a/Pragma_Examples/OpenMP/CXX/8_jacobi/0_jacobi_portyourself/Makefile
+++ b/Pragma_Examples/OpenMP/CXX/8_jacobi/0_jacobi_portyourself/Makefile
@@ -4,22 +4,21 @@
 
 # Compilers and related
 ROCM_PATH     ?= /opt/rocm
-ROCM_GPU      ?= $(INSTALLED_GPU)
-INSTALLED_GPU = $(shell $(ROCM_PATH)/bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
-CFLAG         = -O2 -g --offload-arch=$(ROCM_GPU)
+ROCM_GPU      ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+CXXFLAG       = -O2 -g --offload-arch=$(ROCM_GPU)
 LDFLAG        =
 
 # OpenMP
-COMPILER_OMP  = ${CC} # e.g. $(ROCM_PATH)/llvm/bin/clang++ here: accept from environment
-CFLAGS_OMP    = -fopenmp 
+COMPILER_OMP  = $(CXX) # e.g. $(ROCM_PATH)/llvm/bin/clang++ here: accept from environment
+CXXFLAGS_OMP  = '-fopenmp --offload-arch=${ROCM_GPU}'  #if offload-arch is needed this depends on the compiler chosen!
 LDFLAGS_OMP   =
 
 
 # Source code
-OBJS= Jacobi.o \
-  Laplacian.o \
+OBJS=	Jacobi.o \
+	Laplacian.o \
 	BoundaryConditions.o \
-  Update.o \
+	Update.o \
 	Norm.o \
 	Input.o \
 	Main.o
@@ -34,19 +33,18 @@ omp:
 	@echo "======================="
 	mkdir -p build & mkdir -p build/omp
 	rsync -ru *.cpp *.hpp Makefile build/omp
-	$(MAKE) -C build/$@ jacobi CC=$(COMPILER_OMP) CFLAGS=$(CFLAGS_OMP) LDFLAGS=$(LDFLAGS_OMP)
+	$(MAKE) -C build/$@ jacobi CXX=$(COMPILER_OMP) CXXFLAGS=$(CXXFLAGS_OMP) LDFLAGS=$(LDFLAGS_OMP)
 	cp build/omp/Jacobi ./Jacobi_omp
 
 
 jacobi: $(OBJS)
-	$(CC) $(CFLAG) $(CFLAGS) $(LDFLAG) $(LDFLAGS) -o Jacobi  $(OBJS)
+	$(CXX) $(CXXFLAG) $(CXXFLAGS) $(LDFLAG) $(LDFLAGS) -o Jacobi  $(OBJS)
 
 %.o : %.cpp
-	$(CC) $(CFLAG) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAG) $(CXXFLAGS) -c $< -o $@
 
 clean_omp:
 	rm -rf ./Jacobi_omp build/omp
-
 
 clean: clean_omp
 	rm -rf build/

--- a/Pragma_Examples/OpenMP/CXX/8_jacobi/1_jacobi_usm/Makefile
+++ b/Pragma_Examples/OpenMP/CXX/8_jacobi/1_jacobi_usm/Makefile
@@ -4,26 +4,26 @@
 
 # Compilers and related
 ROCM_PATH     ?= /opt/rocm
-ROCM_GPU      ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//')) 
-CFLAG         = -O2 -g --offload-arch=$(ROCM_GPU)
+ROCM_GPU      ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+CXXFLAG       = -O2 -g --offload-arch=$(ROCM_GPU)
 LDFLAG        =
 
 # OpenMP
-COMPILER_OMP  = $(CC) # e.g. $(ROCM_PATH)/llvm/bin/clang++ here: accept from environment
-CFLAGS_OMP    = '-fopenmp --offload-arch=${ROCM_GPU}'  #if offload-arch is needed this depends on the compiler chosen!
+COMPILER_OMP  = $(CXX) # e.g. $(ROCM_PATH)/llvm/bin/clang++ here: accept from environment
+CXXFLAGS_OMP  = '-fopenmp --offload-arch=${ROCM_GPU}'  #if offload-arch is needed this depends on the compiler chosen!
 LDFLAGS_OMP   =
 
 # HIP
 COMPILER_HIP  = $(ROCM_PATH)/bin/hipcc
-CFLAGS_HIP    = -D_HIP
+CXXFLAGS_HIP  = -D_HIP
 LDFLAGS_HIP   =
 
 
 # Source code
-OBJS= Jacobi.o \
-  Laplacian.o \
+OBJS=	Jacobi.o \
+	Laplacian.o \
 	BoundaryConditions.o \
-  Update.o \
+	Update.o \
 	Norm.o \
 	Input.o \
 	Main.o
@@ -38,19 +38,18 @@ omp:
 	@echo "======================="
 	mkdir -p build & mkdir -p build/omp
 	rsync -ru *.cpp *.hpp Makefile build/omp
-	$(MAKE) -C build/$@ jacobi CC=$(COMPILER_OMP) CFLAGS=$(CFLAGS_OMP) LDFLAGS=$(LDFLAGS_OMP)
+	$(MAKE) -C build/$@ jacobi CXX=$(COMPILER_OMP) CXXFLAGS=$(CXXFLAGS_OMP) LDFLAGS=$(LDFLAGS_OMP)
 	cp build/omp/Jacobi ./Jacobi_omp
 
 
 jacobi: $(OBJS)
-	$(CC) $(CFLAG) $(CFLAGS) $(LDFLAG) $(LDFLAGS) -o Jacobi  $(OBJS)
+	$(CXX) $(CXXFLAG) $(CXXFLAGS) $(LDFLAG) $(LDFLAGS) -o Jacobi  $(OBJS)
 
 %.o : %.cpp
-	$(CC) $(CFLAG) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAG) $(CXXFLAGS) -c $< -o $@
 
 clean_omp:
 	rm -rf ./Jacobi_omp build/omp
-
 
 clean: clean_omp
 	rm -rf build/

--- a/Pragma_Examples/OpenMP/CXX/8_jacobi/2_jacobi_targetdata/Makefile
+++ b/Pragma_Examples/OpenMP/CXX/8_jacobi/2_jacobi_targetdata/Makefile
@@ -4,27 +4,26 @@
 
 # Compilers and related
 ROCM_PATH     ?= /opt/rocm
-ROCM_GPU      ?= $(INSTALLED_GPU)
-INSTALLED_GPU = $(shell $(ROCM_PATH)/bin/rocm_agent_enumerator | grep -m 1 -E gfx[^0]{1})
-CFLAG         = -O2 -g --offload-arch=$(ROCM_GPU)
+ROCM_GPU      ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+CXXFLAG       = -O2 -g --offload-arch=$(ROCM_GPU)
 LDFLAG        =
 
 # OpenMP
-COMPILER_OMP  = $(CC) # e.g. $(ROCM_PATH)/llvm/bin/clang++ here: accept from environment
-CFLAGS_OMP    = -fopenmp
+COMPILER_OMP  = $(CXX) # e.g. $(ROCM_PATH)/llvm/bin/clang++ here: accept from environment
+CXXFLAGS_OMP  = '-fopenmp --offload-arch=${ROCM_GPU}'  #if offload-arch is needed this depends on the compiler chosen!
 LDFLAGS_OMP   =
 
 # HIP
 COMPILER_HIP  = $(ROCM_PATH)/bin/hipcc
-CFLAGS_HIP    = -D_HIP
+CXXFLAGS_HIP  = -D_HIP
 LDFLAGS_HIP   =
 
 
 # Source code
-OBJS= Jacobi.o \
-  Laplacian.o \
+OBJS=	Jacobi.o \
+	Laplacian.o \
 	BoundaryConditions.o \
-  Update.o \
+	Update.o \
 	Norm.o \
 	Input.o \
 	Main.o
@@ -39,19 +38,18 @@ omp:
 	@echo "======================="
 	mkdir -p build & mkdir -p build/omp
 	rsync -ru *.cpp *.hpp Makefile build/omp
-	$(MAKE) -C build/$@ jacobi CC=$(COMPILER_OMP) CFLAGS=$(CFLAGS_OMP) LDFLAGS=$(LDFLAGS_OMP)
+	$(MAKE) -C build/$@ jacobi CXX=$(COMPILER_OMP) CXXFLAGS=$(CXXFLAGS_OMP) LDFLAGS=$(LDFLAGS_OMP)
 	cp build/omp/Jacobi ./Jacobi_omp
 
 
 jacobi: $(OBJS)
-	$(CC) $(CFLAG) $(CFLAGS) $(LDFLAG) $(LDFLAGS) -o Jacobi  $(OBJS)
+	$(CXX) $(CXXFLAG) $(CXXFLAGS) $(LDFLAG) $(LDFLAGS) -o Jacobi  $(OBJS)
 
 %.o : %.cpp
-	$(CC) $(CFLAG) $(CFLAGS) -c $< -o $@
+	$(CXX) $(CXXFLAG) $(CXXFLAGS) -c $< -o $@
 
 clean_omp:
 	rm -rf ./Jacobi_omp build/omp
-
 
 clean: clean_omp
 	rm -rf build/

--- a/Pragma_Examples/OpenMP/CXX/8_jacobi/README.md
+++ b/Pragma_Examples/OpenMP/CXX/8_jacobi/README.md
@@ -1,37 +1,23 @@
 
 ## Porting a small app: jacobi
-### AMD training container environment (aac6):
-```
-module load rocm
-export CC=amdclang++
-```
-Note: CC is used in the Makefile as otherwise the compiler wrappers in the HPE environment on aac7 do not work.
-### Cray environment (aac7):
-```
-module load craype-accel-amd-gfx942
-module load craype-x86-genoa
-module load PrgEnv-amd
-module load rocm
-```
-make sure 
-```
-CC --version´
-```
-shows a c++ compiler.
 
-### Excercise:
+This code is described in detail in this blog: https://rocm.blogs.amd.com/high-performance-computing/jacobi/README.html
 ```
 cd 0_jacobi_portyourself
 ```
-decide if you want to port with or without unified shared memory.
-Either for USM
+decide if you want to port with or without unified shared memory. <hr>
+
+**Either** for USM
 ```
 export HSA_XNACK=1
 ```
-or without for a behaviour with copies
+<hr>
+
+**or** without for a behaviour with copies
 ```
 export HSA_XNACK=0
 ```
+<hr>
 ```
 make
 ```
@@ -47,11 +33,11 @@ otherwise a default of ```<Problemsize> = 4096``` is set.
 On the CPU the default problem size may take a minute to get solved, on the GPU it should be solved in a matter of second(s).
 
 - port the Makefile
-- add omp requires unified memory (in case export HSA_XNACK=1)
+- require unified memory (in case ```export HSA_XNACK=1``` is set)
 - port the loops
 - test functionality and output after each loop you ported
 - make sure the kernels really run on the GPU
-- introduce map clauses (in case ```export HSA_XNACK=1``` is set)
+- introduce map clauses (in case ```export HSA_XNACK=0``` is set)
 - optimize data movement (in case ```export HSA_XNACK=0``` is set)
 
 ## Example solutions:
@@ -62,7 +48,7 @@ cd 1_jacobi_usm
 make
 ./Jacobi_omp
 ```
-compare with your solution (e.g. use vimdiff to compare)
+compare with your solution (e.g. use ```vimdiff``` to compare).
 
 For the discrete GPU / manual memory management version:
 ```
@@ -71,6 +57,4 @@ cd 2_jacobi_targetdata
 make
 ./Jacobi_omp
 ```
-compare the output with your solution, you may want to inspect the solution and compare to your implementation (e.g. use vimdiff to compare)
-
-
+compare with your solution (e.g. use ```vimdiff``` to compare).

--- a/Pragma_Examples/OpenMP/CXX/README.md
+++ b/Pragma_Examples/OpenMP/CXX/README.md
@@ -1,5 +1,86 @@
 
-## Porting of a small app:
+# Porting exercises
+The CXX porting exercises can be found here (this is the directory of this README): 
 ```
-cd 7_jacobi
+cd $HOME/HPCTrainingExamples/Pragma_Examples/OpenMP/CXX
 ```
+#### on aac6: 
+
+Follow the message of the day how to allocate one GPU interactively.
+Load the amdclang compiler and set up the environment 
+```
+module load rocm
+export CXX=amdclang++
+```
+#### on aac7:
+Get an interactive session on a node:
+```
+srun -N 1 --mem=100GB --gpus=1
+```
+Note: you will get 1 GPU and 100 GB of memory. This will allow others to use the remaining resources of a node.
+Useful commands:
+```
+sinfo
+```
+check for available nodes.
+```
+squeue
+```
+check for your job(s). In case it was not terminated correctly, you may have to use
+```
+scancel <JobID>
+```
+to terminate a job.
+
+You can choose the Cray C++ compiler (CC) or the amdclang++ compiler.
+##### amdclang++ compiler on aac7:
+Prepare the environment:
+```
+module load PrgEnv-amd
+module load craype-x86-genoa
+module load craype-accel-amd-gfx942
+module load cce
+module load rocm
+```
+```
+export CXX=CC
+```
+Note that in CPE/25.03 the CC compiler wrapper leads to a segfault at program finalization. Therefore we decided to not recommend to use the compiler wrappers for now on aac7 with amdclang++. If you have rocm 6.3.3 or greater in that version of CPE you should not encounter any issues. You can use it without Cray wrappers by settimg:
+```
+module load rocm
+```
+```
+export CXX=amdclang++
+```
+##### Cray C++ compiler on aac7:
+Prepare the environment:
+```
+module load PrgEnv-cray
+module load craype-x86-genoa
+module load craype-accel-amd-gfx942
+module load cce
+module load rocm
+```
+```
+export CXX=CC
+```
+#### On all systems independent of the compiler:
+This flag
+```
+export HSA_XNACK=1
+```
+will enable no memory copies (use of `unified_shared_memory`) on MI300A
+```
+export HSA_XNACK=0
+```
+will disable this and behave similarly to a discrete GPU with memory copies.
+Check with
+```
+rocminfo
+```
+if ```xnack+``` (unified memory enabled) or ```xnack-``` (with memory copies) is set.
+
+The exercises in the folders are small examples of what one may encounter when porting a real world code. 
+Each exercise has its own README with instructions.
+Exercise 8 is a small app with a Jacobi solver. (Note: This code is explained in detail a blogpost https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-jacobi-readme/.) 
+Choose one of the exercises in the sub-directories and use the README there for instructions.

--- a/Pragma_Examples/OpenMP/Fortran/8_jacobi/README.md
+++ b/Pragma_Examples/OpenMP/Fortran/8_jacobi/README.md
@@ -1,7 +1,7 @@
 
 ## Porting a small app: jacobi
 
-Note: This exercise code and solutions were tested with amdflang-new. Using cray ftn is also possible. Setup the enviroment accordingly.
+Note: This exercise code and solutions were tested with amdflang-new. Using cray ftn is also possible. Setup the environment accordingly.
 
 The C++ version of this code is described in detail https://rocm.blogs.amd.com/high-performance-computing/jacobi/README.html
 
@@ -38,7 +38,7 @@ otherwise a default of ```<Problemsize> = 4096``` is set.
 On the CPU the default problem size may take a minute to get solved, on the GPU it should be solved in a matter of second(s).
 
 - port the Makefile
-- require unified memory (in case export HSA_XNACK=1)
+- require unified memory (in case ```export HSA_XNACK=1``` is set)
 - port the loops
 - test functionality and output after each loop you ported
 - make sure the kernels really run on the GPU
@@ -53,7 +53,7 @@ cd 1_jacobi_usm
 make
 ./jacobi
 ```
-compare with your solution (e.g. use vimdiff to compare)
+compare with your solution (e.g. use ```vimdiff``` to compare).
 
 For the discrete GPU / manual memory management version:
 ```
@@ -62,6 +62,4 @@ cd 2_jacobi_targetdata
 make
 ./jacobi
 ```
-compare with your solution (e.g. use vimdiff to compare)
-
-
+compare with your solution (e.g. use ```vimdiff``` to compare).


### PR DESCRIPTION
- Use `CXX` env variable to set compiler as done in all other CXX examples.
- Add README in parent directory compatible to C and Fortran explaining how to set the compilers