### PR TITLE
OMP/C: Compile C files explicitly with the `C_COMPILER` to avoid mixing with `CC` fallback.

### DIFF
--- a/Pragma_Examples/OpenMP/C/2_vecadd/0_vecadd_portyourself/Makefile
+++ b/Pragma_Examples/OpenMP/C/2_vecadd/0_vecadd_portyourself/Makefile
@@ -32,6 +32,9 @@ else
    LDFLAGS = ${OPENMP_FLAGS} -lm
 endif
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/2_vecadd/1_vecadd_usm/Makefile
+++ b/Pragma_Examples/OpenMP/C/2_vecadd/1_vecadd_usm/Makefile
@@ -33,6 +33,9 @@ else
    LDFLAGS = ${OPENMP_FLAGS} -lm
 endif
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/2_vecadd/2_vecadd_map/Makefile
+++ b/Pragma_Examples/OpenMP/C/2_vecadd/2_vecadd_map/Makefile
@@ -33,6 +33,9 @@ else
    LDFLAGS = ${OPENMP_FLAGS} -lm
 endif
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/2_vecadd/3_vecadd_targetdata/Makefile
+++ b/Pragma_Examples/OpenMP/C/2_vecadd/3_vecadd_targetdata/Makefile
@@ -33,6 +33,9 @@ else
    LDFLAGS = ${OPENMP_FLAGS} -lm
 endif
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/2_vecadd/4_vecadd_async_usm/Makefile
+++ b/Pragma_Examples/OpenMP/C/2_vecadd/4_vecadd_async_usm/Makefile
@@ -33,6 +33,9 @@ else
    LDFLAGS = ${OPENMP_FLAGS} -lm
 endif
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/2_vecadd/5_vecadd_async/Makefile
+++ b/Pragma_Examples/OpenMP/C/2_vecadd/5_vecadd_async/Makefile
@@ -33,6 +33,9 @@ else
    LDFLAGS = ${OPENMP_FLAGS} -lm
 endif
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/3_reduction/0_reduction_portyourself/Makefile
+++ b/Pragma_Examples/OpenMP/C/3_reduction/0_reduction_portyourself/Makefile
@@ -28,6 +28,9 @@ endif
 CFLAGS = -g -O3 -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/3_reduction/1_reduction_solution_usm/Makefile
+++ b/Pragma_Examples/OpenMP/C/3_reduction/1_reduction_solution_usm/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -O3 -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/3_reduction/2_reduction_solution/Makefile
+++ b/Pragma_Examples/OpenMP/C/3_reduction/2_reduction_solution/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -O3 -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/3_reduction/3_reduction_wrongmapping/Makefile
+++ b/Pragma_Examples/OpenMP/C/3_reduction/3_reduction_wrongmapping/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -O3 -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/4_reduction_scalars/0_reduction_scalars_portyourself/Makefile
+++ b/Pragma_Examples/OpenMP/C/4_reduction_scalars/0_reduction_scalars_portyourself/Makefile
@@ -32,6 +32,9 @@ else
    LDFLAGS = ${OPENMP_FLAGS} -lm
 endif
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/4_reduction_scalars/1_reduction_scalars/Makefile
+++ b/Pragma_Examples/OpenMP/C/4_reduction_scalars/1_reduction_scalars/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -O3 -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/5_reduction_array/0_reduction_array_portyourself/Makefile
+++ b/Pragma_Examples/OpenMP/C/5_reduction_array/0_reduction_array_portyourself/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -O3 -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/5_reduction_array/1_reduction_array/Makefile
+++ b/Pragma_Examples/OpenMP/C/5_reduction_array/1_reduction_array/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -O3 -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+${EXEC}.o: ${EXEC}.c
+	$(COMPILER) $(CFLAGS) -c ${EXEC}.c -o ${EXEC}.o
+
 ${EXEC}: ${EXEC}.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/6_device_routines/1_device_routine/0_device_routine_portyourself/Makefile
+++ b/Pragma_Examples/OpenMP/C/6_device_routines/1_device_routine/0_device_routine_portyourself/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+%.o: %.c
+	$(COMPILER) $(CFLAGS) -c -o $@ $<
+
 ${EXEC}: ${EXEC}.o compute.o
 	$(COMPILER) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/6_device_routines/1_device_routine/1_device_routine_usm/Makefile
+++ b/Pragma_Examples/OpenMP/C/6_device_routines/1_device_routine/1_device_routine_usm/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+%.o: %.c
+	$(COMPILER) $(CFLAGS) -c -o $@ $<
+
 ${EXEC}: ${EXEC}.o compute.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/6_device_routines/1_device_routine/2_device_routine_map/Makefile
+++ b/Pragma_Examples/OpenMP/C/6_device_routines/1_device_routine/2_device_routine_map/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+%.o: %.c
+	$(COMPILER) $(CFLAGS) -c -o $@ $<
+
 ${EXEC}: ${EXEC}.o compute.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/6_device_routines/2_device_routine_wglobaldata/0_device_routine_wglobaldata_portyourself/Makefile
+++ b/Pragma_Examples/OpenMP/C/6_device_routines/2_device_routine_wglobaldata/0_device_routine_wglobaldata_portyourself/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+%.o: %.c
+	$(COMPILER) $(CFLAGS) -c -o $@ $<
+
 ${EXEC}: ${EXEC}.o compute.o global_data.o
 	$(COMPILER) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/6_device_routines/2_device_routine_wglobaldata/1_device_routine_wglobaldata/Makefile
+++ b/Pragma_Examples/OpenMP/C/6_device_routines/2_device_routine_wglobaldata/1_device_routine_wglobaldata/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+%.o: %.c
+	$(COMPILER) $(CFLAGS) -c -o $@ $<
+
 ${EXEC}: ${EXEC}.o compute.o global_data.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/6_device_routines/3_device_routine_wdynglobaldata/0_device_routine_wdynglobaldata_portyourself/Makefile
+++ b/Pragma_Examples/OpenMP/C/6_device_routines/3_device_routine_wdynglobaldata/0_device_routine_wdynglobaldata_portyourself/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -O3 -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+%.o: %.c
+	$(COMPILER) $(CFLAGS) -c -o $@ $<
+
 ${EXEC}: ${EXEC}.o compute.o global_data.o
 	$(COMPILER) $(LDFLAGS) $^ -o $@
 

--- a/Pragma_Examples/OpenMP/C/6_device_routines/3_device_routine_wdynglobaldata/1_device_routine_wdynglobaldata/Makefile
+++ b/Pragma_Examples/OpenMP/C/6_device_routines/3_device_routine_wdynglobaldata/1_device_routine_wdynglobaldata/Makefile
@@ -29,6 +29,9 @@ endif
 CFLAGS = -g -O3 -fstrict-aliasing ${OPENMP_FLAGS}
 LDFLAGS = ${OPENMP_FLAGS} -fno-lto -lm
 
+%.o: %.c
+	$(COMPILER) $(CFLAGS) -c -o $@ $<
+
 ${EXEC}: ${EXEC}.o compute.o global_data.o
 	$(COMPILER) $(CFLAGS) $(LDFLAGS) $^ -o $@
 


### PR DESCRIPTION
Some Makefiles did not explicitly state a build rule from `*.c` -> `*.o` but only linking. This meant that the files were compiled with the random `cc` default and only linked with the properly set compiler via `C_COMPILER` or `CC`. This mixing of compilers obviously caused problems.
Added explicit compile steps for all C Makefiles in the enumerated examples to always take the compiler throught the `C_COMPILER`, then `CC` then `amdclang` convention.