### PR TITLE
Update README in OpenMP Fortran

### DIFF
--- a/Pragma_Examples/OpenMP/Fortran/1_saxpy/1_saxpy_omptarget/saxpy.F90
+++ b/Pragma_Examples/OpenMP/Fortran/1_saxpy/1_saxpy_omptarget/saxpy.F90
@@ -1,6 +1,5 @@
 
 module saxpymod
-!$omp requires unified_shared_memory
    use iso_fortran_env
    use omp_lib
   
@@ -8,6 +7,8 @@ module saxpymod
    private
 
    public :: saxpy,initialize
+
+   !$omp requires unified_shared_memory
  
 contains
         

--- a/Pragma_Examples/OpenMP/Fortran/1_saxpy/3_saxpy_paralleldosimd/saxpy.F90
+++ b/Pragma_Examples/OpenMP/Fortran/1_saxpy/3_saxpy_paralleldosimd/saxpy.F90
@@ -6,9 +6,9 @@ module saxpymod
    implicit none
    private
 
-   !$omp requires unified_shared_memory
-   
    public :: saxpy,initialize
+
+   !$omp requires unified_shared_memory
 
 contains
         

--- a/Pragma_Examples/OpenMP/Fortran/1_saxpy/README.md
+++ b/Pragma_Examples/OpenMP/Fortran/1_saxpy/README.md
@@ -19,23 +19,23 @@ to make use of the APU programming model (unified memory).
 
 Load a Fortran compiler module <hr>
 **either**
-The Next Generation AMD Fortran Compiler
+We recommend to use the new LLVM-based `amdflang` Fortran compiler for these exercises. The new LLVM-based `amdflang` compiler is the default Fortran compiler in ROCm since `rocm/7.X` and also in all of the `rocm-afar` or `therock` modules. Depending on the system you are on, you can simply load either
 ```
-module load amdflang-new
+module unload rocm
+module load rocm/7.2.0      # on AAC6
+module load rocm-new/7.2.0  # on AAC7
 ```
-Note: the module sets ```FC``` for you.<hr>
+Note: These modules set ```FC``` for you.<hr>
 
-**or** (only available on systems with CPE installed)
+**or** you can use the Cray Fortran compiler with (only available on systems with CPE installed)
 ```
 module load PrgEnv-cray
 module load rocm
 module load cce
-export FC = ftn
+export FC=ftn
 ```
  <hr>
  
-Note: starting from rocm 7.0, you also can use an older version of the Next Generation AMD Fortran Compiler from ```module load rocm``` and ```export FC=amdflang``` or in environments with CPE installed through ```module load PrgEnv-amd``` ```module load rocm``` ```module load amd``` ```export FC=ftn```. 
-
 Check with 
 ```
 $FC --version
@@ -81,7 +81,7 @@ add ```!$omp target``` to move the loop in the saxpy subroutine to the device.
 Compile this first GPU version.<hr>
 **either**
 Make sure you add ```--offload-arch=gfx942``` (on MI300A, find out what your system's gfx... is with ```rocminfo```)
-on systems with amdflang-new module or rocm 7.x:
+with the `amdflang` compiler.
 ```
 amdflang -fopenmp --offload-arch=gfx942 saxpy.F90 -o saxpy
 ```

--- a/Pragma_Examples/OpenMP/Fortran/2_vecadd/1_vecadd_usm/vecadd.f90
+++ b/Pragma_Examples/OpenMP/Fortran/2_vecadd/1_vecadd_usm/vecadd.f90
@@ -5,6 +5,9 @@ program main
     use omp_lib 
     use, intrinsic :: iso_fortran_env, only: real64
     implicit none
+
+    !$omp requires unified_shared_memory
+
     ! Size of vectors
     integer :: n = 10000000
  
@@ -13,8 +16,6 @@ program main
     integer :: i
     real(real64) :: sum
     real(real64) :: startt, endt
-
-    !$omp requires unified_shared_memory
 
     ! Allocate memory for each vector
     allocate(a(n), b(n), c(n))

--- a/Pragma_Examples/OpenMP/Fortran/2_vecadd/4_vecadd_usm_async/vecadd.f90
+++ b/Pragma_Examples/OpenMP/Fortran/2_vecadd/4_vecadd_usm_async/vecadd.f90
@@ -5,6 +5,9 @@ program main
     use omp_lib 
     use, intrinsic :: iso_fortran_env, only: real64
     implicit none
+
+    !$omp requires unified_shared_memory
+
     ! Size of vectors
     integer :: n = 10000000
  
@@ -14,8 +17,6 @@ program main
     integer :: i
     real(real64) :: sum
     real(real64) :: startt, endt
-
-    !$omp requires unified_shared_memory
  
     ! Allocate memory for each vector
     allocate(a(n), b(n), c(n))

--- a/Pragma_Examples/OpenMP/Fortran/3_reduction/README.md
+++ b/Pragma_Examples/OpenMP/Fortran/3_reduction/README.md
@@ -1,7 +1,7 @@
 
 ## Porting exercise: reduction
 
-README.md from `HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/2_reduction` from the Training Examples repository.
+README.md from `HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/3_reduction` from the Training Examples repository.
 
 This exercise focuses on two things:
 - Part 1: how to port a reduction to the GPU
@@ -50,6 +50,6 @@ The third folder contains an exercise to explore the behavior with and without U
 cd 3_reduction_wrongmapping
 vi freduce.F
 ```
-This example intentionally does the mapping wrong (```from``` instead of ```to```). You can see how the result changes (output 1000 instead of 1010) when you use export ```export XSA_XNACK=0```. No error is shown, but the result is wrong. 
+This example intentionally does the mapping wrong (```from``` instead of ```to```). You can see how the result changes (output 1000 instead of 1010) when you use ```export HSA_XNACK=0```. No error is shown, but the result is wrong.
 Test the same wrong code with ```export HSA_XNACK=1```, then the result is correct again as mapping clauses are ignored.
 Take home message: if you develop for both APUs and discrete GPUs on MI300A, check if the results are the same for ```HSA_XNACK=0``` and ```=1``` as map clauses will be ignored with ```HSA_XNACK=1```! Ignoring memory copies is great for code portability and performance without code changes, but be careful to include proper validation checks during development for both discrete GPUs and APUs.

--- a/Pragma_Examples/OpenMP/Fortran/5_reduction_array/README.md
+++ b/Pragma_Examples/OpenMP/Fortran/5_reduction_array/README.md
@@ -1,7 +1,7 @@
 
 ## Porting exercise reduction of multiple scalars in one kernel
 
-README.md from `HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/9_reduction_array` from the Training Examples repository.
+README.md from `HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/5_reduction_array` from the Training Examples repository.
 
 This folder has two code versions:
 

--- a/Pragma_Examples/OpenMP/Fortran/6_device_routines/README.md
+++ b/Pragma_Examples/OpenMP/Fortran/6_device_routines/README.md
@@ -1,7 +1,7 @@
 
 ## Part 1: Fortran with interface blocks
 
-README.md from `HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/5_device_routines` in Training Examples repository
+README.md from `HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/6_device_routines` in Training Examples repository
 
 Let's start with the device routine in a separate file with an interface.
 

--- a/Pragma_Examples/OpenMP/Fortran/6_device_routines/device_routine_with_module/2_device_routine_with_module_usm/computemod.f90
+++ b/Pragma_Examples/OpenMP/Fortran/6_device_routines/device_routine_with_module/2_device_routine_with_module_usm/computemod.f90
@@ -4,9 +4,11 @@
 
 
        module computemod
-          !$omp requires unified_shared_memory
+          implicit none
           !--- device routine made public
           public :: compute
+
+          !$omp requires unified_shared_memory
 
          contains
           !--- device routine

--- a/Pragma_Examples/OpenMP/Fortran/7_derived_types/README.md
+++ b/Pragma_Examples/OpenMP/Fortran/7_derived_types/README.md
@@ -4,13 +4,13 @@
 README.md in `HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/7_derived_types` of the Training Exercises repository.
 
 This exercise explores the possibilities of mapping derived types. This is one of the main challenges one may encounter when porting a Fortran app to discrete GPUs. This exercise also shows that on the APU using `HSA_XNACK=1` such problems do not exist.
-Note: This exercise was designed for amdflang-new.
+Note: This exercise targets the new LLVM-based **`amdflang`** compiler, which is shipped starting with ROCm/7.0.
 
 Compile the examples:
 ```
 make
 ```
-first, set 
+first, set
 ```
 export HSA_XNACK=0
 ```
@@ -60,24 +60,23 @@ export HSA_XNACK=1
 ```
 Run all the five examples again. All of them should run sucessfully.
 
-Set 
+For `amdflang` set
 ```
 export LIBOMPTARGET_INFO=-1 
 ```
-with the amdflang-new compiler or 
+or, if you work with the `ftn` compiler
 ```
 export CRAY_ACC_DEBUG=1
 
 ```
-if you work with the ftn compiler.
 
-Run example 3  with and without unified shared memory (export HSA_XNACK=1 and  HSA__XNACK=0)
+Run example 3 with and without unified shared memory (`export HSA_XNACK=1` and `export HSA_XNACK=0`)
 You are able to see host to device copies in the shown log in the case of HSA_XNACK=0.
 In the case of HSA_XNACK=1 those copies are gone and this message is shown:
 
 AMDGPU device 0 info: Application configured to run in zero-copy using auto zero-copy.
 
-Hence, if a discrete GPU program is compiled with HSA_XNACK=1 on MI300A, memory copies are automatically ignored. This makes code portable between discrete GPUs an APUs. Include !$omp requires_unified_shared_memory at the top of the program (after implicit none) such that the compiler can make full use of the APU programming model. This is shown in example code 5.
+Hence, if a discrete GPU program is compiled with HSA_XNACK=1 on MI300A, memory copies are automatically ignored. This makes code portable between discrete GPUs and APUs. Include `!$omp requires unified_shared_memory` at the top of the program (after `implicit none`) such that the compiler can make full use of the APU programming model. This is shown in example code 5.
 When you compare the code examples, the unified_shared_memory version dtype_derived_type_usm (version 5) is very simple to implement. If you only work on an APU, this is the easiest way to port, as mapping clauses are not required to obtain good performance.
 
 You may want to set

--- a/Pragma_Examples/OpenMP/Fortran/9_interop/README.md
+++ b/Pragma_Examples/OpenMP/Fortran/9_interop/README.md
@@ -1,19 +1,16 @@
 # Running a Fortran to HIP interop example
 
-README.md `HPCTrainingExamples/Pragma_Examples/OpenMP/Fortran/8_interop` from the Training Examples repository
+README: `Pragma_Examples/OpenMP/Fortran/9_interop`
 
-This is a simple example to demonstrate fortran to HIP interoperability
-
+This is a simple example to demonstrate Fortran to HIP interoperability.
+Load a current ROCm version (at least rocm/7.0) and build with
 ```
-module load rocm
-module load amdflang-new
+module load rocm/7.2.0      # AAC6
+module load rocm-new/7.2.0  # AAC7
 make
 ```
-
-run the code:
-
+Make sure to choose the correct module for the system you are on and run it with
 ```
 ./interop
 ```
-
-Code will run to completion if it passes verification
+The code will run to completion if it passes verification

--- a/Pragma_Examples/OpenMP/Fortran/Atomic/atomic.F
+++ b/Pragma_Examples/OpenMP/Fortran/Atomic/atomic.F
@@ -6,13 +6,13 @@ program atomic_vs_reduction
   use omp_lib
   implicit none
 
+  !$omp requires unified_shared_memory
+
   integer, parameter :: real8 = kind(0.0d0)
   integer, parameter :: N = 10000
   real(real8) :: a(N)
   real(real8) :: sum_of_a, sum_of_a_tmp, tstart
   integer :: i
-
-  !$omp requires unified_shared_memory
 
   !$omp target teams distribute parallel do
   do i = 1, N

--- a/Pragma_Examples/OpenMP/Fortran/optimization/Allocations/3_memorypool/memorypool.f90
+++ b/Pragma_Examples/OpenMP/Fortran/optimization/Allocations/3_memorypool/memorypool.f90
@@ -12,11 +12,11 @@ program main
 
     implicit none
 
+    !$omp requires unified_shared_memory
+
     type(UmpireAllocator) base_allocator
     type(UmpireAllocator) mem_pool
     type(UmpireResourceManager) res_manager
-
-    !$omp requires unified_shared_memory
 
     ! Size of vectors
     integer :: n = 10000000


### PR DESCRIPTION
- Updates README files to new software environment and use mainline `rocm/7.2.0` (or later) compiler for training.
- Fix position of `requires_unified_memory` pragmas. Causes issues for different compilers.