### PR TITLE
Fix specification of GPU arch for Managed Memory examples

### DIFF
--- a/ManagedMemory/APU_Code/Makefile
+++ b/ManagedMemory/APU_Code/Makefile
@@ -1,6 +1,6 @@
 all: gpu_code
 
-AMDGPU_GFXMODEL = $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+AMDGPU_GFXMODEL ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
 
 gpu_code: gpu_code.hip
 	hipcc -g -O3 --offload-arch="${AMDGPU_GFXMODEL}" gpu_code.hip -o gpu_code

--- a/ManagedMemory/GPU_Code/Makefile
+++ b/ManagedMemory/GPU_Code/Makefile
@@ -1,6 +1,6 @@
 all: gpu_code
 
-AMDGPU_GFXMODEL = $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+AMDGPU_GFXMODEL ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
 
 gpu_code: gpu_code.hip
 	hipcc -g -O3 --offload-arch="${AMDGPU_GFXMODEL}" gpu_code.hip -o gpu_code

--- a/ManagedMemory/Managed_Memory_Code/Makefile
+++ b/ManagedMemory/Managed_Memory_Code/Makefile
@@ -1,6 +1,6 @@
 all: gpu_code
 
-AMDGPU_GFXMODEL = $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+AMDGPU_GFXMODEL ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
 
 gpu_code: gpu_code.hip
 	hipcc -g -O3 --offload-arch="${AMDGPU_GFXMODEL}" gpu_code.hip -o gpu_code

--- a/ManagedMemory/OpenMP_Code/Makefile
+++ b/ManagedMemory/OpenMP_Code/Makefile
@@ -1,6 +1,6 @@
 all: openmp_code openmp_code1
 
-AMDGPU_GFXMODEL = $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
+AMDGPU_GFXMODEL ?= $(strip $(shell rocminfo |grep -m 1 -E gfx[^0]{1} | sed -e 's/ *Name: *//'))
 
 CC1=$(notdir $(CC))
 


### PR DESCRIPTION
For managed memory, do not overwrite the specified GPU arch (use `=` ), but only set if not specified already as environment variable (using `?=`) as described in the README.