### PR TITLE
Fix HIP DGEMM example

### DIFF
--- a/HIP/dgemm/CMakeLists.txt
+++ b/HIP/dgemm/CMakeLists.txt
@@ -2,7 +2,7 @@
 #  Copyright (c) 2022, Advanced Micro Devices, Inc. All rights reserved.
 # ***************************************************************************/
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(xGEMM)
 
 # ----------------------------------------------------------------SET CXX STANDARD--

--- a/HIP/dgemm/README.md
+++ b/HIP/dgemm/README.md
@@ -14,8 +14,8 @@ The simpler interface makes it easier to be used in training modules as opposed 
 
 ## Requirements
 
-- cmake > 2.8
-- ROCm > 3.9
+- cmake >= 3.16
+- ROCm >= 6.0
 
 ## Build
 Follow the instructions below to configure and build the `dgemm` binary using the commands:

--- a/HIP/dgemm/src/darray.h
+++ b/HIP/dgemm/src/darray.h
@@ -40,7 +40,7 @@ public:
   };
 
   darray<T> const& operator=(darray<T> && that){
-     m_data = std::move(that.data);
+     m_data = std::move(that.m_data);
      return *this;
   }
 

--- a/HIP/dgemm/src/dgemm.cpp
+++ b/HIP/dgemm/src/dgemm.cpp
@@ -18,36 +18,39 @@ run_dgemm(matrixd const& A, matrixd const& B,
    hipblasHandle_t handle;
    hipblasCreate(&handle);
 
-   hipblasOperation_t const trans_a = HIPBLAS_OP_N;
-   hipblasOperation_t const trans_b = HIPBLAS_OP_T;
-
+   // Matrix dimensions for C = A * B
+   // A is (m x n), B is (n x k), C is (m x k)
    int const m = A.row_count();
    int const n = A.col_count();
    int const k = B.col_count();
-   int const lda = m;
-   int const ldb = n;
-   int const ldc = k;
 
    matrixd C(m, k);
 
-   darray<double> alpha(1);
-   darray<double> beta(1);
    darray<double> A_mat(m*n);
    darray<double> B_mat(n*k);
    darray<double> C_mat(m*k);
 
    double const alpha_val = 1.0;
    double const beta_val = 1.0;
-   hipMemcpy(alpha.data(), &alpha_val, 1*sizeof(double), hipMemcpyHostToDevice);
-   hipMemcpy(beta.data(), &beta_val, 1*sizeof(double), hipMemcpyHostToDevice);
 
-   std::vector<double> mat_zeros(m*n);
-   std::vector<double> mat_out(m*n);
+   std::vector<double> mat_zeros(m*k);
    hipMemcpy(A_mat.data(), &A.data()[0], m*n*sizeof(double), hipMemcpyHostToDevice);
-   hipMemcpy(B_mat.data(), &B.data()[0], m*n*sizeof(double), hipMemcpyHostToDevice);
-   hipMemcpy(C_mat.data(), &mat_zeros[0], m*n*sizeof(double), hipMemcpyHostToDevice);
+   hipMemcpy(B_mat.data(), &B.data()[0], n*k*sizeof(double), hipMemcpyHostToDevice);
+   hipMemcpy(C_mat.data(), &mat_zeros[0], m*k*sizeof(double), hipMemcpyHostToDevice);
 
    dgemm_results ret;
+
+   // hipblasDgemm uses column-major storage, but our matrices are row-major.
+   // To compute C = A * B with row-major matrices using column-major BLAS:
+   //   - Row-major matrix X is seen as X^T by column-major BLAS
+   //   - We use the identity: C = A * B  <=>  C^T = B^T * A^T
+   //   - So we call hipblasDgemm with B and A swapped (no transpose flags)
+   //   - The result C^T in column-major is C in row-major
+   //
+   // hipblasDgemm computes: C_blas = alpha * op(A_blas) * op(B_blas) + beta * C_blas
+   // We call: C_blas = alpha * B_rowmajor * A_rowmajor + beta * C_blas
+   // BLAS sees: C^T = alpha * B^T * A^T + beta * C^T = alpha * (A*B)^T + beta * C^T
+   // Reading C^T as row-major gives us C = alpha * A * B + beta * C
 
    for (int batch_idx=0; batch_idx<iter_count+1; ++batch_idx){
      timer t;
@@ -55,11 +58,11 @@ run_dgemm(matrixd const& A, matrixd const& B,
      for (int i=0; i<rep_count; ++i){
        auto stat = hipblasDgemm(
           handle,
-          trans_a, trans_b,
-          m, n, k,
-          alpha, A_mat, lda,
-          B_mat, ldb,
-          beta,  C_mat, ldc);
+          HIPBLAS_OP_N, HIPBLAS_OP_N,
+          k, m, n,
+          &alpha_val, B_mat.data(), k,
+          A_mat.data(), n,
+          &beta_val, C_mat.data(), k);
      }
      check_stat(hipDeviceSynchronize());
 
@@ -68,10 +71,10 @@ run_dgemm(matrixd const& A, matrixd const& B,
        continue;
      }
 
-     double const dur = t.tock<std::chrono::milliseconds>();
+     double const dur_ms = t.tock<std::chrono::duration<double, std::milli>>();
      double const op_count = rep_count*2.0*m*n*k;
      // ops/ms * 1000ms/1s * 1 gops/1e9 * 1 tops/1e3gops  ops
-     double const tflops = op_count/dur/1.0e9;
+     double const tflops = op_count/dur_ms/1.0e9;
      ret.flops.push_back(tflops);
      ret.time_points.push_back(now_str());
      printf("%d   %3d   %4.2f\n", dev_id, batch_idx, tflops);

--- a/HIP/dgemm/src/main.cpp
+++ b/HIP/dgemm/src/main.cpp
@@ -163,7 +163,7 @@ main(int argc, char *argv[]){
    }
 
    matrixd A = pseudo_random_matrix(arg_list.m, arg_list.n, 0);
-   matrixd B = pseudo_random_matrix(arg_list.m, arg_list.n, 1);
+   matrixd B = pseudo_random_matrix(arg_list.n, arg_list.k, 1);
 
    std::vector<std::future<dgemm_results>> tasks;
    for (auto it=arg_list.device_ids.begin(); it!=arg_list.device_ids.end(); ++it){

--- a/HIP/dgemm/src/timer.h
+++ b/HIP/dgemm/src/timer.h
@@ -23,7 +23,7 @@ public:
   }
 
 private:
-  using time_point = std::chrono::time_point<std::chrono::system_clock>;
+  using time_point = std::chrono::time_point<std::chrono::high_resolution_clock>;
   time_point m_t0;
   time_point m_t1;
 };


### PR DESCRIPTION
 - Fixes wrong dimensions for allocating B and C arrays and associated mem copies
 - Addresses issue with column_major and transpose for hipblas call
 - Directly pass pointers to hipblas via `.data()` call
 - Fixes undefined behavior for calls to clock
 
Validated against CPU reference.