### PR TITLE
Update daxpy_5 code to use the newer roctx library

### DIFF
--- a/HIP-Optimizations/daxpy/Makefile
+++ b/HIP-Optimizations/daxpy/Makefile
@@ -4,8 +4,8 @@ OBJECTS = $(SOURCES:.hip=.o)
 EXECUTABLE = daxpy_1 daxpy_2 daxpy_3 daxpy_4 daxpy_5
 
 HIPCC ?= hipcc
-LDFLAGS ?= -L${ROCM_PATH}/lib -lroctx64
-HIPCCFLAGS += -std=c++17 -Wno-unused-result -O2 -g --save-temps -I${ROCM_PATH}/include/roctracer -I${ROCM_PATH}/include/rocprofiler-sdk-roctx #-Rpass-analysis=kernel-resource-usage
+LDFLAGS ?= -L${ROCM_PATH}/lib -lrocprofiler-sdk-roctx
+HIPCCFLAGS += -std=c++17 -Wno-unused-result -O2 -g --save-temps -I${ROCM_PATH}/include/rocprofiler-sdk-roctx #-Rpass-analysis=kernel-resource-usage
 
 all: ${EXECUTABLE} 
 

--- a/HIP-Optimizations/daxpy/daxpy_5.hip
+++ b/HIP-Optimizations/daxpy/daxpy_5.hip
@@ -11,7 +11,7 @@ Author: Gina Sitaraman
 #include <stdio.h>
 #include <hip/hip_runtime.h>
 #include <sys/time.h>
-#include <roctx.h>
+#include <rocprofiler-sdk-roctx/roctx.h>
 
 #define ELAPSED(t1,t2) (t2.tv_sec-t1.tv_sec + (t2.tv_usec-t1.tv_usec)*1E-6)
 #define NITER 25


### PR DESCRIPTION
Submitting this minor change to use the newer roctx library from rocprofiler-sdk instead of the legacy libraries.