### PR TITLE
Fix profiler and TAU harness checks

### DIFF
--- a/HIP/jacobi/Makefile
+++ b/HIP/jacobi/Makefile
@@ -27,7 +27,13 @@ ifneq ($(USE_CRAYPE),)
   MPICC=CC
 endif
 
-IS_OMPI=$(shell which ompi_info 2>/dev/null)
+# Ask the wrapper we are about to invoke. `which ompi_info` reports that some
+# OpenMPI is installed, which is not the question: with MPICH wrappers in front
+# (any MPICH-built module can pull them in) this branch asked MPICH's mpic++ for
+# --showme:compile, got the flag forwarded to the compiler as an unknown
+# argument, and left both flag sets empty -- so the link had no MPI library and
+# produced a page of undefined symbols.
+IS_OMPI=$(shell ${MPICC} --showme:version >/dev/null 2>&1 && echo openmpi)
 # MPICH detection. The Cray cc/CC wrapper prints "CrayPE is loaded" (matched by
 # 'Cray' below). The standalone mpich-wrappers MPICH on a Cray, however, reports
 # the underlying compiler from `--version` (e.g. "AMD clang"), so grepping the
@@ -56,6 +62,14 @@ else ifneq ($(IS_MPICH),)
     endif
 else
     $(error Unknown MPI version! Currently can detect mpich or openmpi)
+endif
+
+# MPILD is hipcc, not the MPI wrapper, so the MPI library only reaches the link
+# line through MPILDFLAGS. Empty flags therefore produce a page of undefined MPI
+# symbols that names no cause. Fail here instead, while the reason is still
+# visible.
+ifeq ($(strip $(MPILDFLAGS)),)
+    $(error MPI detected but $(strip ${MPICC}) returned no link flags. Two MPIs on PATH is the usual cause: check that mpic++ and any MPI-linked module you loaded are the same MPI)
 endif
 
 # Flags

--- a/HIP/jacobi/Makefile
+++ b/HIP/jacobi/Makefile
@@ -27,12 +27,9 @@ ifneq ($(USE_CRAYPE),)
   MPICC=CC
 endif
 
-# Ask the wrapper we are about to invoke. `which ompi_info` reports that some
-# OpenMPI is installed, which is not the question: with MPICH wrappers in front
-# (any MPICH-built module can pull them in) this branch asked MPICH's mpic++ for
-# --showme:compile, got the flag forwarded to the compiler as an unknown
-# argument, and left both flag sets empty -- so the link had no MPI library and
-# produced a page of undefined symbols.
+# Detect OpenMPI by asking the wrapper itself: only OpenMPI's wrapper answers
+# --showme:version. This is more reliable than checking PATH when more than one
+# MPI is installed.
 IS_OMPI=$(shell ${MPICC} --showme:version >/dev/null 2>&1 && echo openmpi)
 # MPICH detection. The Cray cc/CC wrapper prints "CrayPE is loaded" (matched by
 # 'Cray' below). The standalone mpich-wrappers MPICH on a Cray, however, reports
@@ -64,10 +61,9 @@ else
     $(error Unknown MPI version! Currently can detect mpich or openmpi)
 endif
 
-# MPILD is hipcc, not the MPI wrapper, so the MPI library only reaches the link
-# line through MPILDFLAGS. Empty flags therefore produce a page of undefined MPI
-# symbols that names no cause. Fail here instead, while the reason is still
-# visible.
+# The link is done by hipcc, so MPI reaches it only through MPILDFLAGS. If those
+# came back empty, stop now with the likely cause instead of failing later with
+# undefined MPI symbols.
 ifeq ($(strip $(MPILDFLAGS)),)
     $(error MPI detected but $(strip ${MPICC}) returned no link flags. Two MPIs on PATH is the usual cause: check that mpic++ and any MPI-linked module you loaded are the same MPI)
 endif

--- a/MLExamples/PyTorch_Profiling/rocm-compute-profiler/single_process.sh
+++ b/MLExamples/PyTorch_Profiling/rocm-compute-profiler/single_process.sh
@@ -7,6 +7,39 @@ PROFILER_TOP_DIR="$(dirname "$(dirname "$(readlink -fm "$0")")")"
 # Call the software set up script:
 source ${PROFILER_TOP_DIR}/setup.sh
 
+# Dependency precondition. `analyze` enforces the exact pins in its own
+# requirements.txt and this run ends in `analyze`, so verify them before
+# spending around 25 minutes profiling. Fail fast rather than time out.
+_rpc_bin="$(command -v rocprof-compute 2>/dev/null)"
+if [ -n "${_rpc_bin}" ]; then
+  _rpc_req="$(dirname "$(dirname "${_rpc_bin}")")/libexec/rocprofiler-compute/requirements.txt"
+  if [ -f "${_rpc_req}" ] && ! python3 - "${_rpc_req}" <<'PINS'
+import sys
+from importlib.metadata import version, PackageNotFoundError
+bad = []
+for raw in open(sys.argv[1]):
+    raw = raw.split('#')[0].strip()
+    if not raw or '==' not in raw:
+        continue
+    name, want = raw.split('==', 1)
+    try:
+        have = version(name)
+    except PackageNotFoundError:
+        bad.append('%s: absent (needs %s)' % (name, want)); continue
+    if have != want:
+        bad.append('%s: %s installed, needs %s' % (name, have, want))
+for b in bad:
+    print('  ' + b)
+sys.exit(1 if bad else 0)
+PINS
+  then
+    echo "rocprof-compute dependency pins are unsatisfied under $(python3 -V 2>&1)."
+    echo "'analyze' cannot run, so skipping the profile run instead of timing out."
+    echo "See ${_rpc_req} for the required versions."
+    exit 1
+  fi
+fi
+
 export NPROCS=1
 
 pushd ${PROFILER_TOP_DIR}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1696,11 +1696,11 @@ set_property(TEST Rocprof-sys_ROCm_Run_Check PROPERTY PASS_REGULAR_EXPRESSION "T
 set_property(TEST Rocprof-sys_ROCm_Run_Check PROPERTY SKIP_REGULAR_EXPRESSION "module spider")
 
 add_test(NAME Rocprof-sys_ROCm_Stream_Overlap COMMAND ../rocprof-sys_stream_overlap.sh )
-set_property(TEST Rocprof-sys_ROCm_Stream_Overlap PROPERTY PASS_REGULAR_EXPRESSION "proto")
+set_property(TEST Rocprof-sys_ROCm_Stream_Overlap PROPERTY PASS_REGULAR_EXPRESSION "ROCPROFSYS_STREAM_OVERLAP_RESULT: PASS")
 set_property(TEST Rocprof-sys_ROCm_Stream_Overlap PROPERTY SKIP_REGULAR_EXPRESSION "module spider")
 
 add_test(NAME Rocprof-compute_ROCm_Roofline_Check COMMAND ../rocprof-compute_roofline_check.sh)
-set_property(TEST Rocprof-compute_ROCm_Roofline_Check PROPERTY PASS_REGULAR_EXPRESSION "Empirical Roofline .* saved!")
+set_property(TEST Rocprof-compute_ROCm_Roofline_Check PROPERTY PASS_REGULAR_EXPRESSION "ROOFLINE_RESULT: PASS")
 set_property(TEST Rocprof-compute_ROCm_Roofline_Check PROPERTY SKIP_REGULAR_EXPRESSION "module spider" "disabled on MI300")
 set_tests_properties(Rocprof-compute_ROCm_Roofline_Check PROPERTIES TIMEOUT 600)
 
@@ -1756,19 +1756,19 @@ set_property(TEST JAX_Mnist PROPERTY SKIP_REGULAR_EXPRESSION "module spider" "Un
 # TAU Tests
 
 add_test(NAME TAU_Trace_Check COMMAND ../tau_exec_check.sh --tau-trace)
-set_property(TEST TAU_Trace_Check PROPERTY PASS_REGULAR_EXPRESSION "tautrace.0")
+set_property(TEST TAU_Trace_Check PROPERTY PASS_REGULAR_EXPRESSION "TAU_CHECK: trace artifact PRESENT")
 set_property(TEST TAU_Trace_Check PROPERTY SKIP_REGULAR_EXPRESSION "module spider tau" "Unable to locate a modulefile for 'tau'")
 
 add_test(NAME TAU_Profile_Check COMMAND ../tau_exec_check.sh --tau-profile)
-set_property(TEST TAU_Profile_Check PROPERTY PASS_REGULAR_EXPRESSION "profile.0")
+set_property(TEST TAU_Profile_Check PROPERTY PASS_REGULAR_EXPRESSION "TAU_CHECK: profile artifact PRESENT")
 set_property(TEST TAU_Profile_Check PROPERTY SKIP_REGULAR_EXPRESSION "module spider tau" "Unable to locate a modulefile for 'tau'")
 
 add_test(NAME TAU_Check_HIP_Profile COMMAND ../tau_exec_check.sh --tau-profile)
-set_property(TEST TAU_Check_HIP_Profile PROPERTY PASS_REGULAR_EXPRESSION "hipMemcpy")
+set_property(TEST TAU_Check_HIP_Profile PROPERTY PASS_REGULAR_EXPRESSION "TAU_CHECK: HIP routines PRESENT in profile")
 set_property(TEST TAU_Check_HIP_Profile PROPERTY SKIP_REGULAR_EXPRESSION "module spider tau" "Unable to locate a modulefile for 'tau'")
 
 add_test(NAME TAU_Check_MPI_Profile COMMAND ../tau_exec_check.sh --tau-profile)
-set_property(TEST TAU_Check_MPI_Profile PROPERTY PASS_REGULAR_EXPRESSION "MPI_Allreduce()")
+set_property(TEST TAU_Check_MPI_Profile PROPERTY PASS_REGULAR_EXPRESSION "TAU_CHECK: MPI routines PRESENT in profile")
 set_property(TEST TAU_Check_MPI_Profile PROPERTY SKIP_REGULAR_EXPRESSION "module spider tau" "Unable to locate a modulefile for 'tau'")
 set_property(TEST TAU_Check_MPI_Profile PROPERTY TIMEOUT 600)
 

--- a/tests/rocprof-compute_analyze_check.sh
+++ b/tests/rocprof-compute_analyze_check.sh
@@ -22,5 +22,13 @@ cmake ..
 make
 
 export HSA_XNACK=1
+# rocprof-compute needs Python >= 3.10; native_tool_finder.py uses PEP 604
+# unions. Fail here, naming the reason, rather than later with a SyntaxError
+# from inside the tool that names no cause.
+if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
+  echo "ERROR: rocprof-compute needs Python >= 3.10, but python3 is $(python3 -V 2>&1)."
+  echo "ERROR: load a newer Python before running this test."
+  exit 1
+fi
 rocprof-compute profile -n v1 --no-roof -- ./saxpy
 rocprof-compute analyze -p workloads/v1/* --block 7.1.0 7.1.1 7.1.2 7.1.0: Grid size 7.1.1: Workgroup size 7.1.2: Total Wavefronts

--- a/tests/rocprof-compute_analyze_check.sh
+++ b/tests/rocprof-compute_analyze_check.sh
@@ -22,9 +22,10 @@ cmake ..
 make
 
 export HSA_XNACK=1
-# rocprof-compute needs Python >= 3.10; native_tool_finder.py uses PEP 604
-# unions. Fail here, naming the reason, rather than later with a SyntaxError
-# from inside the tool that names no cause.
+# rocprof-compute needs Python >= 3.10: its native_tool_finder.py annotates with
+# a PEP 604 union (Path | None) and has no "from __future__ import annotations",
+# so on Python 3.9 the annotation raises TypeError at import. Fail here with the
+# reason rather than later from inside the tool.
 if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
   echo "ERROR: rocprof-compute needs Python >= 3.10, but python3 is $(python3 -V 2>&1)."
   echo "ERROR: load a newer Python before running this test."

--- a/tests/rocprof-compute_profile_check.sh
+++ b/tests/rocprof-compute_profile_check.sh
@@ -23,4 +23,12 @@ cmake ..
 make
 
 export HSA_XNACK=1
+# rocprof-compute needs Python >= 3.10; native_tool_finder.py uses PEP 604
+# unions. Fail here, naming the reason, rather than later with a SyntaxError
+# from inside the tool that names no cause.
+if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
+  echo "ERROR: rocprof-compute needs Python >= 3.10, but python3 is $(python3 -V 2>&1)."
+  echo "ERROR: load a newer Python before running this test."
+  exit 1
+fi
 rocprof-compute profile -n v1 --no-roof -- ./saxpy

--- a/tests/rocprof-compute_profile_check.sh
+++ b/tests/rocprof-compute_profile_check.sh
@@ -23,9 +23,10 @@ cmake ..
 make
 
 export HSA_XNACK=1
-# rocprof-compute needs Python >= 3.10; native_tool_finder.py uses PEP 604
-# unions. Fail here, naming the reason, rather than later with a SyntaxError
-# from inside the tool that names no cause.
+# rocprof-compute needs Python >= 3.10: its native_tool_finder.py annotates with
+# a PEP 604 union (Path | None) and has no "from __future__ import annotations",
+# so on Python 3.9 the annotation raises TypeError at import. Fail here with the
+# reason rather than later from inside the tool.
 if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
   echo "ERROR: rocprof-compute needs Python >= 3.10, but python3 is $(python3 -V 2>&1)."
   echo "ERROR: load a newer Python before running this test."

--- a/tests/rocprof-compute_roofline_check.sh
+++ b/tests/rocprof-compute_roofline_check.sh
@@ -30,9 +30,10 @@ cmake ..
 make
 
 export HSA_XNACK=1
-# rocprof-compute needs Python >= 3.10; native_tool_finder.py uses PEP 604
-# unions. Fail here, naming the reason, rather than later with a SyntaxError
-# from inside the tool that names no cause.
+# rocprof-compute needs Python >= 3.10: its native_tool_finder.py annotates with
+# a PEP 604 union (Path | None) and has no "from __future__ import annotations",
+# so on Python 3.9 the annotation raises TypeError at import. Fail here with the
+# reason rather than later from inside the tool.
 if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
   echo "ERROR: rocprof-compute needs Python >= 3.10, but python3 is $(python3 -V 2>&1)."
   echo "ERROR: load a newer Python before running this test."

--- a/tests/rocprof-compute_roofline_check.sh
+++ b/tests/rocprof-compute_roofline_check.sh
@@ -30,4 +30,21 @@ cmake ..
 make
 
 export HSA_XNACK=1
+# rocprof-compute needs Python >= 3.10; native_tool_finder.py uses PEP 604
+# unions. Fail here, naming the reason, rather than later with a SyntaxError
+# from inside the tool that names no cause.
+if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2>/dev/null; then
+  echo "ERROR: rocprof-compute needs Python >= 3.10, but python3 is $(python3 -V 2>&1)."
+  echo "ERROR: load a newer Python before running this test."
+  exit 1
+fi
 rocprof-compute profile -n rooflines_PDF --roof-only  -- ./saxpy
+
+# Assert the roofline artifact exists rather than matching the tool's log
+# wording, which changed when omniperf became rocprofiler-compute.
+_roofline_csv="$(find . -name roofline.csv -size +0 2>/dev/null | head -1)"
+if [ -n "${_roofline_csv}" ]; then
+  echo "ROOFLINE_RESULT: PASS roofline data at ${_roofline_csv}"
+else
+  echo "ROOFLINE_RESULT: FAIL no non-empty roofline.csv produced"
+fi

--- a/tests/rocprof-sys_stream_overlap.sh
+++ b/tests/rocprof-sys_stream_overlap.sh
@@ -126,9 +126,28 @@ ${TOOL_COMMAND}-avail -G $PWD/.configure.cfg
 export ${TOOL_CONFIG}_CONFIG_FILE=$PWD/.configure.cfg
 ${TOOL_COMMAND}-instrument -o compute_comm_overlap.inst -- compute_comm_overlap
 ${TOOL_COMMAND}-run -- ./compute_comm_overlap.inst 2
-cd ${TOOL_OUTPUT}-compute_comm_overlap.inst-output/
-ls *
-
+# Assert a real trace artifact. The tool writes
+# ${TOOL_NAME}-compute_comm_overlap.inst-output (rocprofiler-systems-... on
+# ROCm > 6.2.9, omnitrace-... before it), NOT ${TOOL_OUTPUT}-...  Glob for the
+# suffix so both eras work, and require a real .proto inside it.
+assert_proto_output() {
+  local outdir n
+  outdir="$(ls -d ./*-compute_comm_overlap.inst-output 2>/dev/null | head -1)"
+  if [[ -z "${outdir}" || ! -d "${outdir}" ]]; then
+    echo "ROCPROFSYS_STREAM_OVERLAP_RESULT: FAIL no *-compute_comm_overlap.inst-output directory produced"
+    return 1
+  fi
+  # The tool nests a timestamped subdirectory, so recurse.
+  n="$(find "${outdir}" -type f -name '*.proto' | wc -l)"
+  find "${outdir}" -type f | sed 's/^/    /' | head -20
+  if [[ "${n}" -gt 0 ]]; then
+    echo "ROCPROFSYS_STREAM_OVERLAP_RESULT: PASS ${n} proto file(s) under ${outdir}"
+  else
+    echo "ROCPROFSYS_STREAM_OVERLAP_RESULT: FAIL 0 proto files under ${outdir}"
+    return 1
+  fi
+}
+assert_proto_output
 cd ..
 rm -rf ${BUILD_DIR}
 

--- a/tests/rocprof-sys_stream_overlap.sh
+++ b/tests/rocprof-sys_stream_overlap.sh
@@ -126,10 +126,9 @@ ${TOOL_COMMAND}-avail -G $PWD/.configure.cfg
 export ${TOOL_CONFIG}_CONFIG_FILE=$PWD/.configure.cfg
 ${TOOL_COMMAND}-instrument -o compute_comm_overlap.inst -- compute_comm_overlap
 ${TOOL_COMMAND}-run -- ./compute_comm_overlap.inst 2
-# Assert a real trace artifact. The tool writes
-# ${TOOL_NAME}-compute_comm_overlap.inst-output (rocprofiler-systems-... on
-# ROCm > 6.2.9, omnitrace-... before it), NOT ${TOOL_OUTPUT}-...  Glob for the
-# suffix so both eras work, and require a real .proto inside it.
+# Check for a real .proto artifact instead of matching tool output. The output
+# directory name differs between omnitrace and rocprofiler-systems, so glob on
+# the shared suffix and require a .proto inside it.
 assert_proto_output() {
   local outdir n
   outdir="$(ls -d ./*-compute_comm_overlap.inst-output 2>/dev/null | head -1)"

--- a/tests/tau_exec_check.sh
+++ b/tests/tau_exec_check.sh
@@ -89,10 +89,8 @@ trap 'cd "${SRCDIR}" && rm -rf "${WORKDIR}"' EXIT
 cp ${SRCDIR}/*.hip ${SRCDIR}/*.hpp ${SRCDIR}/*.h ${SRCDIR}/Makefile ${SRCDIR}/input.txt ${WORKDIR}/
 cd ${WORKDIR}
 
-# A failed build has to end the test. Without this gate make's status was
-# ignored, tau_exec profiled a binary that was never produced, and the script
-# still exited 0 because cleanup was the last command -- leaving the whole
-# verdict to the pass regex.
+# Stop the test if the build fails, otherwise tau_exec would go on to profile a
+# binary that was never produced.
 if ! make; then
    echo "TAU_CHECK: build FAILED, so nothing was profiled"
    exit 1
@@ -121,7 +119,7 @@ result=""; ver_gt "${ROCM_VERSION}" 6.1.9 && result="${ROCM_VERSION}"; echo $res
 # ("MPI processes (2) doesn't match the topology size (1)"). Only a bare Cray
 # MPICH (mpicc with no co-located launcher) falls back to srun. The MPICH hydra
 # mpiexec also rejects OpenMPI's --oversubscribe, so add that flag for OpenMPI
-# only (detected via ompi_info).
+# only (detected from the MPI wrapper below).
 MPI_BINDIR=$(dirname "$(command -v mpicc 2>/dev/null)" 2>/dev/null)
 if [ -n "${MPI_BINDIR}" ] && [ -x "${MPI_BINDIR}/mpirun" ]; then
    MPI_LAUNCH="${MPI_BINDIR}/mpirun -n 2"
@@ -130,12 +128,9 @@ elif [ -n "${MPI_BINDIR}" ] && [ -x "${MPI_BINDIR}/mpiexec" ]; then
 else
    MPI_LAUNCH="srun -n 2"
 fi
-# Ask the wrapper we are about to invoke, not the PATH. `command -v ompi_info`
-# answers "is some OpenMPI installed", which is a different question. An
-# MPICH-built TAU module makes the two disagree: loading it pulls in
-# mpich-wrappers, so mpicc/mpic++/mpiexec become MPICH's while ompi_info still
-# reports the OpenMPI that is no longer in front. --showme:version succeeds only
-# on OpenMPI and -compile_info only on MPICH, so each wrapper answers for itself.
+# Ask the launch wrapper which MPI it is: only OpenMPI answers --showme:version
+# and only MPICH answers -compile_info. This is more reliable than checking PATH,
+# since a module can put one MPI's wrappers in front of another's.
 MPI_FAMILY=unknown
 if [ -n "${MPI_BINDIR}" ]; then
    if "${MPI_BINDIR}/mpicc" --showme:version >/dev/null 2>&1; then
@@ -149,25 +144,12 @@ if [ "${MPI_FAMILY}" = "openmpi" ]; then
    MPI_LAUNCH="${MPI_LAUNCH} --oversubscribe"
 fi
 
-# Keep both ranks on the node that owns the build directory. Jacobi is compiled
-# into a mktemp directory inside this checkout, so if the checkout lives on
-# node-local storage rather than a shared filesystem, a multi-node allocation
-# lets the launcher place rank 1 on a node where that path does not exist. The
-# run then dies before the test body starts:
-#
-#   error: couldn't chdir to `/tmp/.../HIP/jacobi/build_ewLCPv': No such file or
-#   directory: going to /tmp instead
-#   [proxy:1@node2] launch_procs: unable to change wdir to /tmp/.../build_ewLCPv
-#
-# The test wants two ranks, not two nodes -- Jacobi's "-g 2 1" topology on two
-# GPUs of one node -- so pinning costs no coverage. Hydra takes -hosts; OpenMPI
-# takes --host with a slot count. Measured on two nodes: bare mpirun aborts as
-# above, both pinned forms put rank 0 and rank 1 on the same node.
-#
-# The srun fallback is left alone deliberately: it is reached only for a bare
-# MPICH with no co-located launcher, and the obvious addition there
-# (--nodes=1 --nodelist=...) needs the step's GRES respecified or Slurm rejects
-# the step outright, so a blind flag would trade a rare failure for a common one.
+# Run both ranks on this node. The test needs two ranks on two GPUs, not two
+# nodes, and Jacobi is built in a directory inside the checkout. If that checkout
+# is on node-local storage, a multi-node launch could place a rank on a node that
+# cannot see the build directory. Hydra takes -hosts, OpenMPI takes --host with a
+# slot count. The srun fallback is left as is, because pinning it would also need
+# the step's GRES respecified.
 MPI_HOST_LOCAL="$(hostname -s)"
 case "${MPI_LAUNCH}" in
    srun*) ;;
@@ -190,10 +172,9 @@ fi
 ls
 pprof 2>&1 | tee pprof.out
 
-# Assert the artifacts. Matching the tool's own vocabulary is what made these
-# tests unable to fail: "profile.0" is a substring of "Could not open
-# profile.0.0.0". Assert the artifact and the profiled routines instead, in
-# strings the failure paths cannot produce, and let CMake match these.
+# Check for the produced files and print our own result strings, which CMake
+# matches on. Matching the tool's own words was unreliable: "profile.0" also
+# appears in messages like "Could not open profile.0.0.0".
 tau_have() { ls $1 >/dev/null 2>&1; }
 tau_status=0
 

--- a/tests/tau_exec_check.sh
+++ b/tests/tau_exec_check.sh
@@ -84,10 +84,23 @@ export TAU_PROFILE=${TAU_PROFILE}
 export TAU_TRACE=${TAU_TRACE}
 
 WORKDIR=$(mktemp -d -p ${SRCDIR} build_XXXXXX)
+# Install the cleanup trap before the build gate below, which can exit early.
+trap 'cd "${SRCDIR}" && rm -rf "${WORKDIR}"' EXIT
 cp ${SRCDIR}/*.hip ${SRCDIR}/*.hpp ${SRCDIR}/*.h ${SRCDIR}/Makefile ${SRCDIR}/input.txt ${WORKDIR}/
 cd ${WORKDIR}
 
-make
+# A failed build has to end the test. Without this gate make's status was
+# ignored, tau_exec profiled a binary that was never produced, and the script
+# still exited 0 because cleanup was the last command -- leaving the whole
+# verdict to the pass regex.
+if ! make; then
+   echo "TAU_CHECK: build FAILED, so nothing was profiled"
+   exit 1
+fi
+if [ ! -x ./Jacobi_hip ]; then
+   echo "TAU_CHECK: build reported success but ./Jacobi_hip is missing"
+   exit 1
+fi
 
 ROCM_VERSION=`cat ${ROCM_PATH}/.info/version | head -1 | cut -f1 -d'-' `
 
@@ -117,9 +130,54 @@ elif [ -n "${MPI_BINDIR}" ] && [ -x "${MPI_BINDIR}/mpiexec" ]; then
 else
    MPI_LAUNCH="srun -n 2"
 fi
-if command -v ompi_info >/dev/null 2>&1; then
+# Ask the wrapper we are about to invoke, not the PATH. `command -v ompi_info`
+# answers "is some OpenMPI installed", which is a different question. An
+# MPICH-built TAU module makes the two disagree: loading it pulls in
+# mpich-wrappers, so mpicc/mpic++/mpiexec become MPICH's while ompi_info still
+# reports the OpenMPI that is no longer in front. --showme:version succeeds only
+# on OpenMPI and -compile_info only on MPICH, so each wrapper answers for itself.
+MPI_FAMILY=unknown
+if [ -n "${MPI_BINDIR}" ]; then
+   if "${MPI_BINDIR}/mpicc" --showme:version >/dev/null 2>&1; then
+      MPI_FAMILY=openmpi
+   elif "${MPI_BINDIR}/mpicc" -compile_info >/dev/null 2>&1; then
+      MPI_FAMILY=mpich
+   fi
+fi
+echo "TAU_CHECK: launching with ${MPI_FAMILY} wrappers from ${MPI_BINDIR:-<none, using srun>}"
+if [ "${MPI_FAMILY}" = "openmpi" ]; then
    MPI_LAUNCH="${MPI_LAUNCH} --oversubscribe"
 fi
+
+# Keep both ranks on the node that owns the build directory. Jacobi is compiled
+# into a mktemp directory inside this checkout, so if the checkout lives on
+# node-local storage rather than a shared filesystem, a multi-node allocation
+# lets the launcher place rank 1 on a node where that path does not exist. The
+# run then dies before the test body starts:
+#
+#   error: couldn't chdir to `/tmp/.../HIP/jacobi/build_ewLCPv': No such file or
+#   directory: going to /tmp instead
+#   [proxy:1@node2] launch_procs: unable to change wdir to /tmp/.../build_ewLCPv
+#
+# The test wants two ranks, not two nodes -- Jacobi's "-g 2 1" topology on two
+# GPUs of one node -- so pinning costs no coverage. Hydra takes -hosts; OpenMPI
+# takes --host with a slot count. Measured on two nodes: bare mpirun aborts as
+# above, both pinned forms put rank 0 and rank 1 on the same node.
+#
+# The srun fallback is left alone deliberately: it is reached only for a bare
+# MPICH with no co-located launcher, and the obvious addition there
+# (--nodes=1 --nodelist=...) needs the step's GRES respecified or Slurm rejects
+# the step outright, so a blind flag would trade a rare failure for a common one.
+MPI_HOST_LOCAL="$(hostname -s)"
+case "${MPI_LAUNCH}" in
+   srun*) ;;
+   *) case "${MPI_FAMILY}" in
+         openmpi) MPI_LAUNCH="${MPI_LAUNCH} --host ${MPI_HOST_LOCAL}:2" ;;
+         mpich)   MPI_LAUNCH="${MPI_LAUNCH} -hosts ${MPI_HOST_LOCAL}" ;;
+         *) echo "TAU_CHECK: unknown MPI family, not pinning ranks to ${MPI_HOST_LOCAL}" ;;
+      esac ;;
+esac
+echo "TAU_CHECK: launcher is ${MPI_LAUNCH}"
 
 # Use a 1024x1024 local mesh so the TAU trace buffer fits in GPU memory
 # (default 4096x4096 caused "HIP failure: 'out of memory'" during trace finalization).
@@ -130,8 +188,43 @@ else
 fi
 
 ls
-pprof
+pprof 2>&1 | tee pprof.out
 
-cd ..
-rm -rf ${WORKDIR}
+# Assert the artifacts. Matching the tool's own vocabulary is what made these
+# tests unable to fail: "profile.0" is a substring of "Could not open
+# profile.0.0.0". Assert the artifact and the profiled routines instead, in
+# strings the failure paths cannot produce, and let CMake match these.
+tau_have() { ls $1 >/dev/null 2>&1; }
+tau_status=0
 
+if [ "${TAU_PROFILE}" = "1" ]; then
+   if tau_have 'profile.*'; then
+      echo "TAU_CHECK: profile artifact PRESENT"
+   else
+      echo "TAU_CHECK: profile artifact absent"
+      tau_status=1
+   fi
+   # Reported but not fatal on their own: each is a different test's subject, so
+   # the per-test expression decides rather than failing all of them together.
+   if grep -q 'MPI_Allreduce' pprof.out; then
+      echo "TAU_CHECK: MPI routines PRESENT in profile"
+   else
+      echo "TAU_CHECK: MPI routines absent from profile"
+   fi
+   if grep -q 'hipMemcpy' pprof.out; then
+      echo "TAU_CHECK: HIP routines PRESENT in profile"
+   else
+      echo "TAU_CHECK: HIP routines absent from profile"
+   fi
+fi
+
+if [ "${TAU_TRACE}" = "1" ]; then
+   if tau_have 'tautrace.*'; then
+      echo "TAU_CHECK: trace artifact PRESENT"
+   else
+      echo "TAU_CHECK: trace artifact absent"
+      tau_status=1
+   fi
+fi
+
+exit ${tau_status}

--- a/tests/tau_rccl_pc_check.sh
+++ b/tests/tau_rccl_pc_check.sh
@@ -113,7 +113,21 @@ elif [ -n "${MPI_BINDIR}" ] && [ -x "${MPI_BINDIR}/mpiexec" ]; then
 else
    MPI_LAUNCH="srun -n 2"
 fi
-if command -v ompi_info >/dev/null 2>&1; then
+# Ask the wrapper we are about to invoke; see tau_exec_check.sh for the detail.
+# Testing whether ompi_info exists added OpenMPI's --oversubscribe to MPICH's
+# hydra mpiexec, which rejects it. Note this does not by itself make the test
+# pass where TAU and the prebuilt rccl-tests binary come from different MPIs:
+# an MPICH-built TAU cannot instrument an OpenMPI-linked benchmark.
+MPI_FAMILY=unknown
+if [ -n "${MPI_BINDIR}" ]; then
+   if "${MPI_BINDIR}/mpicc" --showme:version >/dev/null 2>&1; then
+      MPI_FAMILY=openmpi
+   elif "${MPI_BINDIR}/mpicc" -compile_info >/dev/null 2>&1; then
+      MPI_FAMILY=mpich
+   fi
+fi
+echo "MPI family of ${MPI_BINDIR:-<none, using srun>}: ${MPI_FAMILY}"
+if [ "${MPI_FAMILY}" = "openmpi" ]; then
    MPI_LAUNCH="${MPI_LAUNCH} --oversubscribe"
 fi
 

--- a/tests/tau_rccl_pc_check.sh
+++ b/tests/tau_rccl_pc_check.sh
@@ -113,11 +113,10 @@ elif [ -n "${MPI_BINDIR}" ] && [ -x "${MPI_BINDIR}/mpiexec" ]; then
 else
    MPI_LAUNCH="srun -n 2"
 fi
-# Ask the wrapper we are about to invoke; see tau_exec_check.sh for the detail.
-# Testing whether ompi_info exists added OpenMPI's --oversubscribe to MPICH's
-# hydra mpiexec, which rejects it. Note this does not by itself make the test
-# pass where TAU and the prebuilt rccl-tests binary come from different MPIs:
-# an MPICH-built TAU cannot instrument an OpenMPI-linked benchmark.
+# Detect the MPI flavour from the launch wrapper; see tau_exec_check.sh. Checking
+# PATH instead could add OpenMPI's --oversubscribe to MPICH's mpiexec, which
+# rejects it. This does not fix the case where TAU and the prebuilt rccl-tests
+# binary come from different MPIs.
 MPI_FAMILY=unknown
 if [ -n "${MPI_BINDIR}" ]; then
    if "${MPI_BINDIR}/mpicc" --showme:version >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

This PR fixes several profiler and TAU test harness issues found while validating the AAC7 OpenMPI row.

- Profiler tests now assert produced artifacts instead of matching fragile tool output, and the
  corresponding CTest pass expressions are updated to match.
- TAU checks now fail on build failure and assert real profile/trace artifacts.
- TAU and Jacobi MPI detection now query the active MPI wrapper instead of checking whether `ompi_info`
  exists somewhere on `PATH`.
- Jacobi-based TAU launches avoid placing ranks on nodes that cannot see the node-local build
  directory.
- The PyTorch rocprof-compute run checks the dependency pins that `analyze` enforces before profiling,
  and the rocprof-compute tests fail immediately, with the reason, when Python is older than 3.10.
  These are reported as failures rather than skips deliberately, so the failure count is not quietly
  reduced.

## Why

Several tests could pass or fail for the wrong reason:

- Some pass regexes matched diagnostic text printed on failure. `profile.0` is a substring of
  `Could not open profile.0.0.0`, and `proto` appears in output the tool prints when it produces
  nothing.
- One TAU script continued after `make` failed, so the final verdict depended only on regex output.
  Because `PASS_REGULAR_EXPRESSION` overrides the exit code, the script and the CMake criteria had to
  be fixed together.
- MPI detection confused mixed environments where OpenMPI's `ompi_info` was visible but `mpic++` had
  been replaced by MPICH wrappers.
- The PyTorch profiling run spent about 25 minutes profiling before reaching an `analyze` step that
  could not run, turning a dependency problem into a timeout that named no cause.

## Validation

Validated on AAC7 with the OpenMPI PrgEnv row: MI300A, ROCm 7.14.0, OpenMPI 5.0.10 over OFI/CXI.

- The six tests whose pass criteria this PR rewrites were run against these exact changes and all
  pass: `Rocprof-sys_ROCm_Stream_Overlap`, `Rocprof-compute_ROCm_Roofline_Check`, `TAU_Trace_Check`,
  `TAU_Profile_Check`, `TAU_Check_HIP_Profile` and `TAU_Check_MPI_Profile`. Each now matches on a
  string only the success path can produce.
- The rocprof-compute Python precondition was exercised in both directions. Under Python 3.9.21 the
  test fails in about three seconds, reporting the version it found and the version it needs. Under
  Python 3.12.12 it runs to completion and the roofline assertion finds a real `roofline.csv`. The
  failing case is deliberately a failure rather than a skip, so an environment that cannot run
  rocprof-compute is not quietly removed from the failure count.
- A single-node GPU probe showed that the detection and pass-criteria fixes make the Jacobi-based TAU
  tests build and produce real `profile.*` / `tautrace.*` artifacts and `pprof` output containing MPI
  and HIP routines.
- The full AAC7 two-node suite then exposed a separate launch-directory issue: the tests built under
  node-local `/tmp`, but rank 1 was launched on the second node where that directory did not exist. This
  PR fixes that launch assumption too, by keeping the ranks on the node that owns the build directory.
  Verified on two nodes with the checkout in node-local `/tmp` — the failure reproduces without the fix
  and both invocations pass with it — and then in the full two-node suite, where all four Jacobi TAU
  tests pass on real artifacts (319 pass / 27 fail / 15 skip / 1 timeout of 362, suspicious-pass 0).
- Three TAU RCCL tests still fail for an environment/package reason: MPICH-built TAU cannot instrument
  the OpenMPI-built `rccl-tests` benchmark. This PR does not attempt to solve that packaging mismatch.
- The rocprof-sys PyTorch thread explosion is tracked separately as a rocprof-sys issue, not as a test
  harness bug.