### PR TITLE
Add Slurm batch scripts and AAC6 guide for shallow-water profiling

### DIFF
--- a/Profiling-by-example/shallow-water/.gitignore
+++ b/Profiling-by-example/shallow-water/.gitignore
@@ -1,0 +1,2 @@
+env.sh
+!**/profile.sh

--- a/Profiling-by-example/shallow-water/AAC6.md
+++ b/Profiling-by-example/shallow-water/AAC6.md
@@ -1,0 +1,238 @@
+# Shallow-Water Profiling on AAC6
+
+This page is the site guide for the
+[Profiling-by-example shallow-water](../README.md) tutorials on AAC6.
+The novice and advanced READMEs explain the profiling workflow and what each stage
+teaches; here we cover only what is specific to AAC6 and the batch scripts provided
+with the tutorial tree.
+
+Hardware: MI300A on AAC6, ROCm `10.1.0a20260818` from the Ubuntu 24.04 nightlies
+module tree.
+
+## Repository layout
+
+```
+Profiling-by-example/shallow-water/
+  env_aac6.sh                  # AAC6 template — copy to env.sh and edit
+  env.sh                       # your local copy (not in git)
+  setup_rocprof_compute_venv.sh
+  setup_roofline_extractor_venv.sh
+  submit.sh                    # sbatch wrapper (reads partition from env.sh)
+  novice/0_baseline/ … 4_block_64x4/
+    fom.sh                     # build, run, print MCUPS
+    profile.sh                 # profiling and roofline commands for this stage
+  advanced/0_baseline/ … 6_2d_decomposition/
+    fom.sh
+    profile.sh
+    gpu_bind.sh                # per-rank GPU binding, two-NUMA nodes
+    gpu_bind_cpx.sh            # per-rank GPU binding, single-NUMA nodes
+```
+
+Work through stages in order. Each stage directory builds on its own; the change
+from one stage to the next is a few lines of source, documented in that stage's
+README.
+
+## One-time setup (login node)
+
+Run these once after cloning or updating the repository.
+
+```bash
+cd Profiling-by-example/shallow-water
+cp env_aac6.sh env.sh
+# edit env.sh: set SLURM_PARTITION and, for advanced jobs, GPU_BIND / MPI_BIND
+# optional: ROCPROFSYS_NETWORK_INTERFACE for NIC profiling (advanced stages 5–6)
+./setup_rocprof_compute_venv.sh
+export ROOFLINE_EXTRACTOR=/nfsapps/ubuntu-24.04/opt/rooflineExtractor
+./setup_roofline_extractor_venv.sh
+chmod +x submit.sh setup_rocprof_compute_venv.sh setup_roofline_extractor_venv.sh
+chmod +x novice/*/fom.sh novice/*/profile.sh
+chmod +x advanced/*/fom.sh advanced/*/profile.sh
+```
+
+`env.sh` holds your local settings: Slurm partition, module versions, and
+advanced-track MPI binding. It is gitignored so your settings stay local to
+your setup.
+
+For the advanced track, set `GPU_BIND` and `MPI_BIND` in `env.sh` to match
+your node layout: `gpu_bind.sh` with `--map-by ppr:1:numa --bind-to numa`
+on nodes with two NUMA domains, or `gpu_bind_cpx.sh` with `--map-by slot`
+on single-NUMA nodes. The template comments show both pairs.
+
+For NIC counter profiling in advanced stages 5–6, set `ROCPROFSYS_NETWORK_INTERFACE`
+in `env.sh` to your node's HPC interface name after checking on a compute node:
+
+```bash
+rocprof-sys-avail -H -r net
+```
+
+NIC profiling blocks in the batch scripts are commented out until multi-node jobs
+are available on AAC6; the variable can be set now so it is ready when those runs
+are re-enabled.
+
+`setup_rocprof_compute_venv.sh` creates `~/rocprof-compute-venv` and installs
+the pinned Python packages that `rocprof-compute analyze` needs. Run it on a
+login node where `pip` can reach the package index; compute nodes may not have
+outbound network access.
+
+Novice `profile.sh` scripts collect a roofline plot using whichever backend
+`ROOFLINE_TOOL` selects in `env.sh`: `extractor` (default) runs
+[`profile_app.py`](https://github.com/AMD-HPC/rooflineExtractor/blob/main/README.md);
+`rocprof-compute` runs the `--roof-only` profile and analyze steps instead.
+
+On AAC6, `env_aac6.sh` sets `ROOFLINE_EXTRACTOR` to the site install at
+`/nfsapps/ubuntu-24.04/opt/rooflineExtractor` — that path supplies
+`profile_app.py` and `requirements.txt`; no git clone is needed. Python
+dependencies come from `~/roofline-venv` (created by
+`setup_roofline_extractor_venv.sh` on a login node and activated in `env.sh`).
+The `module load roofline-extractor/dev` line in `profile.sh` is a harmless
+fallback when the venv is missing; it is not required once the venv exists.
+
+On other systems, clone the repo, run `./setup_roofline_extractor_venv.sh`, and
+set `ROOFLINE_EXTRACTOR` in `env.sh` (see the [novice README](novice/README.md#roofline-plots)).
+
+If AAC6 moves to a different ROCm build, edit the `module load` lines in
+`env.sh` to match.
+
+### Validating all batch scripts
+
+A separate validation harness can sync the tutorial tree to AAC6, submit every
+`fom.sh` and `profile.sh` sequentially, wait for each job, print pass/fail, and
+collect roofline plots. Expect several hours of queue time for the full run.
+
+## Submitting jobs
+
+Every stage has two scripts:
+
+| Script | Purpose |
+|---|---|
+| `fom.sh` | Build with `make`, run the solver, print throughput (MCUPS) and correctness checks |
+| `profile.sh` | Build, then run profiling commands from that stage's README (including roofline extractor on novice stages) |
+
+Submit from inside the stage directory. Partition name comes from `env.sh`, not
+from the `#SBATCH` lines (Slurm cannot expand shell variables there), so we use
+`submit.sh`:
+
+```bash
+cd novice/0_baseline
+../../submit.sh fom.sh
+../../submit.sh profile.sh
+```
+
+Output lands in the stage directory as `fom_<jobid>.out` or
+`profile_<jobid>.out`.
+
+Check queue status:
+
+```bash
+squeue -u "$USER"
+```
+
+When the job has left the queue, read the result:
+
+```bash
+cat fom_*.out
+# or
+less profile_12345.out
+```
+
+## Novice track (one GPU)
+
+Five stages, single-process HIP. Each `fom.sh` requests one GPU and 30 minutes;
+each `profile.sh` requests one GPU and two hours (rocprof and roofline collection).
+
+```bash
+cd novice/0_baseline
+../../submit.sh fom.sh        # expect ~6282 MCUPS (stage 0 baseline)
+../../submit.sh profile.sh    # kernel trace, occupancy, roofline extractor
+```
+
+Then continue through `1_larger_domain`, `2_no_device_sync`, `3_block_32x32`, and
+`4_block_64x4`. The stage READMEs list the expected MCUPS at each step.
+
+## Advanced track (MPI, up to four GPUs)
+
+Seven stages, multi-GPU MPI. Each `fom.sh` requests one exclusive node with four
+GPUs and two hours. The script runs scaling loops at 1, 2, and 4 ranks using
+`GPU_BIND` and `MPI_BIND` from `env.sh`. See the
+[advanced README](advanced/README.md#affinity-which-decides-everything-else).
+
+```bash
+cd advanced/0_baseline
+../../submit.sh fom.sh
+../../submit.sh profile.sh
+```
+
+The `--exclusive` flag in the advanced batch scripts is load-bearing: without it,
+ranks share a handful of CPU threads remote from the GPUs and timings are not
+meaningful. Do not remove it.
+
+Stage 6 `fom.sh` also builds stage 5 and compares slab vs tile decomposition.
+Stage 5 and 6 `profile.sh` capture single-node `rocprof-sys` timelines at 4 ranks.
+Stage 6 traces slab vs tile decomposition. Open Perfetto output at
+[ui.perfetto.dev](https://ui.perfetto.dev).
+
+NIC counter runs (`advanced/nic_trace.sh`, steps 10–29, two nodes) are commented
+out in the batch scripts until multi-node jobs are available on AAC6. The stage
+6 README has the full recipe; set `ROCPROFSYS_NETWORK_INTERFACE` in `env.sh`
+after `rocprof-sys-avail -H -r net`.
+
+## Things to keep in mind
+
+**Login node vs compute node.** Module loads and `setup_rocprof_compute_venv.sh`
+belong on the login node. Batch jobs load modules again via `env.sh` when they
+start on a compute node.
+
+**`env.sh` must exist before you submit.** Both `submit.sh` and every batch
+script source `${SW_ROOT}/env.sh`. If you skip `cp env_aac6.sh env.sh` or leave
+`SLURM_PARTITION` unset, submission fails immediately.
+
+**`rocprof-compute analyze` and the venv.** Profile scripts call `analyze` after
+`profile`. That requires the virtual environment from the one-time setup. If
+`analyze` reports missing Python packages, re-run `setup_rocprof_compute_venv.sh`
+on a login node.
+
+**Roofline Extractor and Python.** Novice `profile.sh` scripts call
+`profile_app.py` from `ROOFLINE_EXTRACTOR`. On AAC6 the install and Python deps
+come from `~/roofline-venv` (see one-time setup); elsewhere use
+`setup_roofline_extractor_venv.sh`.
+
+**Counter and profile runtimes.** Profiling replays or multiplexes kernel
+dispatches and can take much longer than a plain FOM run. Use `fom.sh` when you
+only need throughput; reserve `profile.sh` for when you are collecting data.
+
+**Output directories.** Profiling writes into the stage directory: `outdir/`,
+`workloads/`, `trace/`, and similar paths listed in each track's `.gitignore`.
+These can be large; remove them between stages if disk quota is tight.
+
+**Correctness checks.** Every FOM run prints mass conservation and minimum depth.
+If mass error jumps by orders of magnitude after an advanced-stage change, the
+answer is wrong even if throughput improved. The stage 5 README shows an example
+where a missing stream dependency passes a timer but fails physics.
+
+**Numbers in the READMEs are reference points.** They were measured on MI300A in
+SPX mode. Your absolute MCUPS will differ; the trends (occupancy rising with
+domain size, communication dominating at small scale, and so on) are what matter.
+
+## Quick reference: stages
+
+| Track | Stage | Main idea |
+|---|---|---|
+| novice | `0_baseline` | Starting point; kernel trace and occupancy |
+| novice | `1_larger_domain` | 512² → 2048² domain |
+| novice | `2_no_device_sync` | Remove redundant `hipDeviceSynchronize()` |
+| novice | `3_block_32x32` | 16×16 → 32×32 blocks |
+| novice | `4_block_64x4` | 32×32 → 64×4 blocks |
+| advanced | `0_baseline` | Scaling study; communication vs compute |
+| advanced | `1_larger_domain` | 512² → 8192² global domain |
+| advanced | `2_block_32x32` | Larger thread blocks |
+| advanced | `3_block_64x4` | Wavefront-shaped blocks |
+| advanced | `4_vectorized_loads` | Thread trace; explicit wide loads |
+| advanced | `5_halo_pipeline` | Overlap halo exchange with compute |
+| advanced | `6_2d_decomposition` | 2D tile vs 1D slab |
+
+## Further reading
+
+- [Novice track README](novice/README.md)
+- [Advanced track README](advanced/README.md)
+- [ROCm profiling guide, novice (blog)](https://rocm.blogs.amd.com/software-tools-optimization/profiling-guide/novice/README.html)
+- [ROCm profiling guide, advanced (blog)](https://rocm.blogs.amd.com/software-tools-optimization/profiling-guide/advanced/README.html)

--- a/Profiling-by-example/shallow-water/README.md
+++ b/Profiling-by-example/shallow-water/README.md
@@ -20,6 +20,8 @@ Start with [`novice`](novice) unless you have already profiled single-process GP
 advanced track separates raw speed from scalability, and spends its second half on communication and
 decomposition rather than on kernels.
 
+On AAC6, see [AAC6.md](AAC6.md) for site-specific setup and batch submission.
+
 ## The application
 
 The code solves the 2D shallow-water equations over a flat bed, which describe the depth and momentum

--- a/Profiling-by-example/shallow-water/advanced/.gitignore
+++ b/Profiling-by-example/shallow-water/advanced/.gitignore
@@ -2,14 +2,28 @@
 shallow_mpi
 shallow_mpi.inst
 
-# rocprofv3 output, from the -d argument used in the stage READMEs
+# Slurm logs from fom.sh / profile.sh
+fom_*.out
+profile_*.out
+
+# rocprofv3 output
 prof/
 outdir/
+results_*
+
+# ATT (-o att in profile.sh)
+att/
 att_out/
+att_results.db
+att_*.att
 
-# rocprof-compute workload directories
+# rocprof-compute
 workloads/
+rocprof_compute_compare.txt
 
-# rocprof-sys output
+# rocprof-sys (-o trace, trace_full, trace_n*, trace_slab, trace_tile, nic*)
+trace/
+trace_*/
 rocprof-sys-*-output/
 rocprofsys.cfg
+nic*

--- a/Profiling-by-example/shallow-water/advanced/0_baseline/fom.sh
+++ b/Profiling-by-example/shallow-water/advanced/0_baseline/fom.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-0-fom
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+for n in 1 2 4; do
+    mpirun -n $n ${MPI_BIND} ${GPU_BIND} ./shallow_mpi
+done

--- a/Profiling-by-example/shallow-water/advanced/0_baseline/profile.sh
+++ b/Profiling-by-example/shallow-water/advanced/0_baseline/profile.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-0-profile
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+mpirun -n 2 ${MPI_BIND} ${GPU_BIND} \
+    rocprofv3 --kernel-trace --stats -S -T -f csv \
+    -o results_%env{OMPI_COMM_WORLD_RANK}% -- ./shallow_mpi
+
+mpirun -n 2 ${MPI_BIND} ${GPU_BIND} \
+    rocprof-sys-run --preset=trace-hpc --flat-profile -o trace_full -- ./shallow_mpi
+
+mpirun -n 2 ${MPI_BIND} ${GPU_BIND} \
+    rocprof-sys-run --preset=trace-hpc --flat-profile \
+    --selected-regions step_3,step_4,step_5 -o trace -- ./shallow_mpi

--- a/Profiling-by-example/shallow-water/advanced/1_larger_domain/fom.sh
+++ b/Profiling-by-example/shallow-water/advanced/1_larger_domain/fom.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-1-fom
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+for n in 1 2 4; do
+    mpirun -n $n ${MPI_BIND} ${GPU_BIND} ./shallow_mpi
+done

--- a/Profiling-by-example/shallow-water/advanced/1_larger_domain/profile.sh
+++ b/Profiling-by-example/shallow-water/advanced/1_larger_domain/profile.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-1-profile
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+mpirun -n 2 ${MPI_BIND} ${GPU_BIND} \
+    rocprofv3 --pmc VALUBusy -T -f csv \
+    -o results_%env{OMPI_COMM_WORLD_RANK}% -- ./shallow_mpi
+
+rocprof-compute profile -n 1_larger_domain --overwrite --no-roof -k compute_rhs \
+    --iteration-multiplexing -- ./shallow_mpi
+rocprof-compute analyze -p "${STAGE_DIR}/workloads/1_larger_domain/0" \
+        -b 2.1.0 2.1.9 2.1.14 2.1.15 2.1.18 2.1.19 2.1.20 2.1.21 \
+        > "${STAGE_DIR}/rocprof_compute_compare.txt"

--- a/Profiling-by-example/shallow-water/advanced/2_block_32x32/fom.sh
+++ b/Profiling-by-example/shallow-water/advanced/2_block_32x32/fom.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-2-fom
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+for n in 1 2 4; do
+    mpirun -n $n ${MPI_BIND} ${GPU_BIND} ./shallow_mpi
+done

--- a/Profiling-by-example/shallow-water/advanced/2_block_32x32/profile.sh
+++ b/Profiling-by-example/shallow-water/advanced/2_block_32x32/profile.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-2-profile
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+rocprofv3 --att --att-activity 8 --kernel-include-regex compute_rhs \
+    -o att -- ./shallow_mpi
+
+mpirun -n 2 ${MPI_BIND} ${GPU_BIND} \
+    rocprofv3 --pmc VALUBusy -T -f csv \
+    -o results_%env{OMPI_COMM_WORLD_RANK}% -- ./shallow_mpi
+
+PREV_WL="$(cd "${STAGE_DIR}/../1_larger_domain" && pwd)/workloads/1_larger_domain/0"
+CUR_WL="${STAGE_DIR}/workloads/2_block_32x32/0"
+
+rocprof-compute profile -n 2_block_32x32 --overwrite --no-roof -k compute_rhs \
+    --iteration-multiplexing -- ./shallow_mpi
+rocprof-compute analyze -p "$PREV_WL" -p "$CUR_WL" \
+        -b 2.1.0 2.1.9 2.1.14 2.1.15 2.1.18 2.1.19 2.1.20 2.1.21 \
+        > "${STAGE_DIR}/rocprof_compute_compare.txt"

--- a/Profiling-by-example/shallow-water/advanced/3_block_64x4/fom.sh
+++ b/Profiling-by-example/shallow-water/advanced/3_block_64x4/fom.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-3-fom
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+for n in 1 2 4; do
+    mpirun -n $n ${MPI_BIND} ${GPU_BIND} ./shallow_mpi
+done

--- a/Profiling-by-example/shallow-water/advanced/3_block_64x4/profile.sh
+++ b/Profiling-by-example/shallow-water/advanced/3_block_64x4/profile.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-3-profile
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+rocprofv3 --att --att-activity 8 --kernel-include-regex compute_rhs \
+    -o att -- ./shallow_mpi
+
+PREV_WL="$(cd "${STAGE_DIR}/../2_block_32x32" && pwd)/workloads/2_block_32x32/0"
+CUR_WL="${STAGE_DIR}/workloads/3_block_64x4/0"
+
+rocprof-compute profile -n 3_block_64x4 --overwrite --no-roof -k compute_rhs \
+    --iteration-multiplexing -- ./shallow_mpi
+rocprof-compute analyze -p "$PREV_WL" -p "$CUR_WL" \
+        -b 2.1.0 2.1.9 2.1.14 2.1.15 2.1.18 2.1.19 2.1.20 2.1.21 15.1.1 \
+        > "${STAGE_DIR}/rocprof_compute_compare.txt"

--- a/Profiling-by-example/shallow-water/advanced/4_vectorized_loads/fom.sh
+++ b/Profiling-by-example/shallow-water/advanced/4_vectorized_loads/fom.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-4-fom
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+for n in 1 2 4; do
+    mpirun -n $n ${MPI_BIND} ${GPU_BIND} ./shallow_mpi
+done

--- a/Profiling-by-example/shallow-water/advanced/4_vectorized_loads/profile.sh
+++ b/Profiling-by-example/shallow-water/advanced/4_vectorized_loads/profile.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-4-profile
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+rocprofv3 --att --att-activity 8 --kernel-include-regex compute_rhs \
+    -o att -- ./shallow_mpi
+
+PREV_WL="$(cd "${STAGE_DIR}/../3_block_64x4" && pwd)/workloads/3_block_64x4/0"
+CUR_WL="${STAGE_DIR}/workloads/4_vectorized_loads/0"
+
+rocprof-compute profile -n 4_vectorized_loads --overwrite --no-roof -k compute_rhs \
+    --iteration-multiplexing -- ./shallow_mpi
+rocprof-compute analyze -p "$PREV_WL" -p "$CUR_WL" \
+        -b 2.1.0 2.1.9 2.1.14 2.1.15 2.1.18 2.1.19 2.1.20 2.1.21 15.1.1 \
+        > "${STAGE_DIR}/rocprof_compute_compare.txt"
+
+for n in 2 4; do
+    mpirun -n $n ${MPI_BIND} ${GPU_BIND} \
+        rocprof-sys-run --preset=trace-hpc --flat-profile \
+        --selected-regions step_3,step_4,step_5 -o trace_n$n -- ./shallow_mpi
+done
+
+mpirun -n 4 ${MPI_BIND} ${GPU_BIND} \
+    rocprofv3 --kernel-trace --stats -S -T -f csv \
+    -o results_%env{OMPI_COMM_WORLD_RANK}% -- ./shallow_mpi
+
+# rocprof-compute profile -n 4_vectorized_loads --overwrite --roof-only --device 0 -k compute_rhs \
+#     --iteration-multiplexing -- ./shallow_mpi
+# rocprof-compute analyze -p "${STAGE_DIR}/workloads/4_vectorized_loads/0"

--- a/Profiling-by-example/shallow-water/advanced/5_halo_pipeline/fom.sh
+++ b/Profiling-by-example/shallow-water/advanced/5_halo_pipeline/fom.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-5-fom
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+for n in 1 2 4; do
+    mpirun -n $n ${MPI_BIND} ${GPU_BIND} ./shallow_mpi
+done

--- a/Profiling-by-example/shallow-water/advanced/5_halo_pipeline/profile.sh
+++ b/Profiling-by-example/shallow-water/advanced/5_halo_pipeline/profile.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-5-profile
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+# source "${SW_ROOT}/advanced/nic_trace.sh"
+
+make clean && make
+
+mpirun -n 4 ${MPI_BIND} ${GPU_BIND} \
+    rocprof-sys-run --preset=trace-hpc --flat-profile \
+    --selected-regions step_3,step_4,step_5 -o trace -- ./shallow_mpi
+
+# NIC trace: needs -N 2 and nic_trace.sh; see stage 6 README.
+# if [ -n "${ROCPROFSYS_NETWORK_INTERFACE:-}" ]; then
+#     run_nic_trace 8 nic ./shallow_mpi
+# fi

--- a/Profiling-by-example/shallow-water/advanced/6_2d_decomposition/fom.sh
+++ b/Profiling-by-example/shallow-water/advanced/6_2d_decomposition/fom.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-6-fom
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+make -C ../5_halo_pipeline
+for n in 1 2 4; do
+    echo "=== slab (stage 5), $n ranks ==="
+    mpirun -n $n ${MPI_BIND} ${GPU_BIND} ../5_halo_pipeline/shallow_mpi
+    echo "=== tile (stage 6), $n ranks ==="
+    mpirun -n $n ${MPI_BIND} ${GPU_BIND} ./shallow_mpi
+done

--- a/Profiling-by-example/shallow-water/advanced/6_2d_decomposition/profile.sh
+++ b/Profiling-by-example/shallow-water/advanced/6_2d_decomposition/profile.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH --job-name=sw-adv-6-profile
+#SBATCH -N 1
+#SBATCH --exclusive
+#SBATCH --gres=gpu:4
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+# source "${SW_ROOT}/advanced/nic_trace.sh"
+
+make clean && make
+make -C ../5_halo_pipeline
+
+mpirun -n 4 ${MPI_BIND} ${GPU_BIND} \
+    rocprof-sys-run --preset=trace-hpc --flat-profile \
+    --selected-regions step_3,step_4,step_5 -o trace_slab -- ../5_halo_pipeline/shallow_mpi
+
+mpirun -n 4 ${MPI_BIND} ${GPU_BIND} \
+    rocprof-sys-run --preset=trace-hpc --flat-profile \
+    --selected-regions step_3,step_4,step_5 -o trace_tile -- ./shallow_mpi
+
+# NIC trace: needs -N 2 and nic_trace.sh; see stage 6 README.
+# if [ -n "${ROCPROFSYS_NETWORK_INTERFACE:-}" ]; then
+#     run_nic_trace 8 nic_slab ../5_halo_pipeline/shallow_mpi
+#     run_nic_trace 8 nic_tile ./shallow_mpi
+# fi

--- a/Profiling-by-example/shallow-water/advanced/gpu_bind_cpx.sh
+++ b/Profiling-by-example/shallow-water/advanced/gpu_bind_cpx.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Per-rank GPU visibility for MI300A in CPX mode (single NUMA node, six GPUs).
+#
+# Usage, from a stage directory inside an --exclusive allocation:
+#   mpirun -n 4 --map-by slot ../gpu_bind_cpx.sh ./shallow_mpi
+#
+# CPX nodes expose one NUMA domain, so use --map-by slot rather than ppr:1:numa.
+# Each rank sees GPU local_rank via ROCR_VISIBLE_DEVICES.
+
+LRANK=${OMPI_COMM_WORLD_LOCAL_RANK:-${SLURM_LOCALID:-${PMI_LOCAL_RANK:-0}}}
+
+export ROCR_VISIBLE_DEVICES=$LRANK
+exec "$@"

--- a/Profiling-by-example/shallow-water/advanced/nic_trace.sh
+++ b/Profiling-by-example/shallow-water/advanced/nic_trace.sh
@@ -1,0 +1,9 @@
+NIC_STEPS=$(printf "step_%s," {10..29})
+NIC_STEPS=${NIC_STEPS%,}
+
+run_nic_trace() {
+    local ranks=$1 out=$2 binary=$3
+    mpirun -n "$ranks" ${MPI_BIND} ${GPU_BIND} \
+        rocprof-sys-run --preset=trace-hpc --flat-profile \
+        --selected-regions "$NIC_STEPS" -o "$out" -- "$binary"
+}

--- a/Profiling-by-example/shallow-water/env_aac6.sh
+++ b/Profiling-by-example/shallow-water/env_aac6.sh
@@ -1,0 +1,51 @@
+# Site environment for the shallow-water profiling tutorials on AAC6.
+# Copy once, then edit for your account:
+#   cp env_aac6.sh env.sh
+#
+# Set SLURM_PARTITION to the partition your account uses on AAC6.
+# For the advanced track, pick the GPU_BIND / MPI_BIND pair that matches
+# your node layout (see AAC6.md).
+
+export SLURM_PARTITION=
+
+source /etc/profile.d/lmod.sh
+source /shared/apps/ubuntu/lmod/overridetcl2lmod.sh
+
+module use /nfsapps/ubuntu-24.04-nightlies/modules/base
+module load rocm/10.1.0a20260818
+module load openmpi
+
+# Two NUMA domains (typical SPX layout):
+export GPU_BIND="../gpu_bind.sh"
+export MPI_BIND="--map-by ppr:1:numa --bind-to numa"
+# Single NUMA domain (typical CPX layout):
+# export GPU_BIND="../gpu_bind_cpx.sh"
+# export MPI_BIND="--map-by slot"
+
+# NIC profiling (advanced stages 5–6). Set after: rocprof-sys-avail -H -r net
+export ROCPROFSYS_NETWORK_INTERFACE=
+if [ -n "${ROCPROFSYS_NETWORK_INTERFACE}" ]; then
+    _nic=${ROCPROFSYS_NETWORK_INTERFACE}
+    export ROCPROFSYS_PAPI_EVENTS="net:::${_nic}:rx:byte net:::${_nic}:rx:packet net:::${_nic}:tx:byte net:::${_nic}:tx:packet"
+    export ROCPROFSYS_TIMEMORY_COMPONENTS="wall_clock network_stats"
+    export ROCPROFSYS_USE_SAMPLING=true
+    export ROCPROFSYS_SAMPLING_FREQ=100
+fi
+
+export ROOFLINE_EXTRACTOR=/nfsapps/ubuntu-24.04/opt/rooflineExtractor
+
+# Novice profile.sh roofline backend: extractor (default) or rocprof-compute
+export ROOFLINE_TOOL=extractor
+# export ROOFLINE_TOOL=rocprof-compute
+
+export ROOFLINE_VENV="${HOME}/roofline-venv"
+if [ -f "${ROOFLINE_VENV}/bin/activate" ]; then
+    source "${ROOFLINE_VENV}/bin/activate"
+fi
+
+# rocprof-compute analyze needs a login-node venv (see setup_rocprof_compute_venv.sh).
+export ROCprof_COMPUTE_VENV="${HOME}/rocprof-compute-venv"
+if [ -f "${ROCprof_COMPUTE_VENV}/bin/activate" ]; then
+    source "${ROCprof_COMPUTE_VENV}/bin/activate"
+    python3 -m pip install -r "${ROCM_PATH}/libexec/rocprofiler-compute/requirements.txt"
+fi

--- a/Profiling-by-example/shallow-water/novice/.gitignore
+++ b/Profiling-by-example/shallow-water/novice/.gitignore
@@ -1,9 +1,14 @@
 # Built executable
 shallow
 
+# Slurm logs from fom.sh / profile.sh
+fom_*.out
+profile_*.out
+
 # rocprofv3 output, from the -d argument used in the stage READMEs
 outdir/
 prof/
+roofline_out/
 
-# rocprof-compute workload directories
+# rocprof-compute workload directories (ROOFLINE_TOOL=rocprof-compute)
 workloads/

--- a/Profiling-by-example/shallow-water/novice/0_baseline/README.md
+++ b/Profiling-by-example/shallow-water/novice/0_baseline/README.md
@@ -116,9 +116,11 @@ because there is not enough boundary to go around.
 A roofline plot places a kernel against the machine's compute and bandwidth ceilings, which tells us
 whether it is limited by arithmetic or by memory traffic.
 
+`profile_app.py` in Roofline Extractor needs its
+[Python environment](../README.md#a-python-environment-for-roofline-extractor) active:
+
 ```bash
-module load rocm roofline-extractor
-roofline-extractor-profile -o roofline_out --arch MI300A -- ./shallow
+python3 "$ROOFLINE_EXTRACTOR/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
 ```
 
 The equivalent in `rocprof-compute`, whose `analyze` step needs its

--- a/Profiling-by-example/shallow-water/novice/0_baseline/fom.sh
+++ b/Profiling-by-example/shallow-water/novice/0_baseline/fom.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-0-fom
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=00:30:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+./shallow

--- a/Profiling-by-example/shallow-water/novice/0_baseline/profile.sh
+++ b/Profiling-by-example/shallow-water/novice/0_baseline/profile.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-0-profile
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+rocprofv3 --kernel-trace --stats -S -T -d outdir -o shallow -- ./shallow
+
+rocprofv3 --pmc OccupancyPercent -T --output-format csv -d outdir -o shallow -- ./shallow
+
+if [ "${ROOFLINE_TOOL:-extractor}" = rocprof-compute ]; then
+    rocprof-compute profile -n 0_baseline --overwrite --roof-only --device 0 -k compute_rhs \
+        --iteration-multiplexing -- ./shallow
+    rocprof-compute analyze -p "${STAGE_DIR}/workloads/0_baseline/0"
+else
+    : "${ROOFLINE_EXTRACTOR:?Set ROOFLINE_EXTRACTOR in env.sh to your rooflineExtractor checkout}"
+
+    module use /nfsapps/ubuntu-24.04/modules/base 2>/dev/null || true
+    module load roofline-extractor/dev 2>/dev/null || true
+
+    python3 "${ROOFLINE_EXTRACTOR}/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
+fi

--- a/Profiling-by-example/shallow-water/novice/1_larger_domain/README.md
+++ b/Profiling-by-example/shallow-water/novice/1_larger_domain/README.md
@@ -79,12 +79,15 @@ rocprofv3 --pmc OccupancyPercent -T --output-format csv -d outdir -o shallow -- 
 The main kernels went from roughly a quarter of the machine to roughly four fifths of it. The
 roofline tells the same story from a different angle:
 
+`profile_app.py` in Roofline Extractor needs its
+[Python environment](../README.md#a-python-environment-for-roofline-extractor) active:
+
 ```bash
-module load rocm roofline-extractor
-roofline-extractor-profile -o roofline_out --arch MI300A -- ./shallow
+python3 "$ROOFLINE_EXTRACTOR/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
 ```
 
-The equivalent in `rocprof-compute`:
+The equivalent in `rocprof-compute`, whose `analyze` step needs its
+[Python environment](../README.md#a-python-environment-for-rocprof-compute-analyze) active:
 
 ```bash
 rocprof-compute profile -n 1_larger_domain --roof-only --device 0 -k compute_rhs --iteration-multiplexing -- ./shallow

--- a/Profiling-by-example/shallow-water/novice/1_larger_domain/fom.sh
+++ b/Profiling-by-example/shallow-water/novice/1_larger_domain/fom.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-1-fom
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=00:30:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+./shallow

--- a/Profiling-by-example/shallow-water/novice/1_larger_domain/profile.sh
+++ b/Profiling-by-example/shallow-water/novice/1_larger_domain/profile.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-1-profile
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+rocprofv3 --pmc OccupancyPercent -T --output-format csv -d outdir -o shallow -- ./shallow
+
+rocprofv3 --kernel-trace --hip-trace -d outdir -o shallow -- ./shallow
+rocpd2pftrace -i outdir/shallow_results.db -d outdir -o shallow
+
+if [ "${ROOFLINE_TOOL:-extractor}" = rocprof-compute ]; then
+    rocprof-compute profile -n 1_larger_domain --overwrite --roof-only --device 0 -k compute_rhs \
+        --iteration-multiplexing -- ./shallow
+    rocprof-compute analyze -p "${STAGE_DIR}/workloads/1_larger_domain/0"
+else
+    : "${ROOFLINE_EXTRACTOR:?Set ROOFLINE_EXTRACTOR in env.sh to your rooflineExtractor checkout}"
+
+    module use /nfsapps/ubuntu-24.04/modules/base 2>/dev/null || true
+    module load roofline-extractor/dev 2>/dev/null || true
+
+    python3 "${ROOFLINE_EXTRACTOR}/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
+fi

--- a/Profiling-by-example/shallow-water/novice/2_no_device_sync/README.md
+++ b/Profiling-by-example/shallow-water/novice/2_no_device_sync/README.md
@@ -67,12 +67,15 @@ The kernels now abut one another instead of being separated by host round trips.
 
 ## Step 2: Check the roofline again
 
+`profile_app.py` in Roofline Extractor needs its
+[Python environment](../README.md#a-python-environment-for-roofline-extractor) active:
+
 ```bash
-module load rocm roofline-extractor
-roofline-extractor-profile -o roofline_out --arch MI300A -- ./shallow
+python3 "$ROOFLINE_EXTRACTOR/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
 ```
 
-The equivalent in `rocprof-compute`:
+The equivalent in `rocprof-compute`, whose `analyze` step needs its
+[Python environment](../README.md#a-python-environment-for-rocprof-compute-analyze) active:
 
 ```bash
 rocprof-compute profile -n 2_no_device_sync --roof-only --device 0 -k compute_rhs --iteration-multiplexing -- ./shallow

--- a/Profiling-by-example/shallow-water/novice/2_no_device_sync/fom.sh
+++ b/Profiling-by-example/shallow-water/novice/2_no_device_sync/fom.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-2-fom
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=00:30:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+./shallow

--- a/Profiling-by-example/shallow-water/novice/2_no_device_sync/profile.sh
+++ b/Profiling-by-example/shallow-water/novice/2_no_device_sync/profile.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-2-profile
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+rocprofv3 --kernel-trace --hip-trace -d outdir -o shallow -- ./shallow
+rocpd2pftrace -i outdir/shallow_results.db -d outdir -o shallow
+
+rocprofv3 --pmc VALUBusy -T --output-format csv -d outdir -o shallow -- ./shallow
+
+if [ "${ROOFLINE_TOOL:-extractor}" = rocprof-compute ]; then
+    rocprof-compute profile -n 2_no_device_sync --overwrite --roof-only --device 0 -k compute_rhs \
+        --iteration-multiplexing -- ./shallow
+    rocprof-compute analyze -p "${STAGE_DIR}/workloads/2_no_device_sync/0"
+else
+    : "${ROOFLINE_EXTRACTOR:?Set ROOFLINE_EXTRACTOR in env.sh to your rooflineExtractor checkout}"
+
+    module use /nfsapps/ubuntu-24.04/modules/base 2>/dev/null || true
+    module load roofline-extractor/dev 2>/dev/null || true
+
+    python3 "${ROOFLINE_EXTRACTOR}/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
+fi

--- a/Profiling-by-example/shallow-water/novice/3_block_32x32/README.md
+++ b/Profiling-by-example/shallow-water/novice/3_block_32x32/README.md
@@ -101,12 +101,15 @@ Always validate against the wall clock.
 
 ## Roofline
 
+`profile_app.py` in Roofline Extractor needs its
+[Python environment](../README.md#a-python-environment-for-roofline-extractor) active:
+
 ```bash
-module load rocm roofline-extractor
-roofline-extractor-profile -o roofline_out --arch MI300A -- ./shallow
+python3 "$ROOFLINE_EXTRACTOR/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
 ```
 
-The equivalent in `rocprof-compute`:
+The equivalent in `rocprof-compute`, whose `analyze` step needs its
+[Python environment](../README.md#a-python-environment-for-rocprof-compute-analyze) active:
 
 ```bash
 rocprof-compute profile -n 3_block_32x32 --roof-only --device 0 -k compute_rhs --iteration-multiplexing -- ./shallow

--- a/Profiling-by-example/shallow-water/novice/3_block_32x32/fom.sh
+++ b/Profiling-by-example/shallow-water/novice/3_block_32x32/fom.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-3-fom
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=00:30:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+./shallow

--- a/Profiling-by-example/shallow-water/novice/3_block_32x32/profile.sh
+++ b/Profiling-by-example/shallow-water/novice/3_block_32x32/profile.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-3-profile
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+rocprofv3 --pmc VALUBusy -T --output-format csv -d outdir -o shallow -- ./shallow
+
+rocprofv3 --pmc OccupancyPercent -T --output-format csv -d outdir -o shallow -- ./shallow
+
+if [ "${ROOFLINE_TOOL:-extractor}" = rocprof-compute ]; then
+    rocprof-compute profile -n 3_block_32x32 --overwrite --roof-only --device 0 -k compute_rhs \
+        --iteration-multiplexing -- ./shallow
+    rocprof-compute analyze -p "${STAGE_DIR}/workloads/3_block_32x32/0"
+else
+    : "${ROOFLINE_EXTRACTOR:?Set ROOFLINE_EXTRACTOR in env.sh to your rooflineExtractor checkout}"
+
+    module use /nfsapps/ubuntu-24.04/modules/base 2>/dev/null || true
+    module load roofline-extractor/dev 2>/dev/null || true
+
+    python3 "${ROOFLINE_EXTRACTOR}/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
+fi

--- a/Profiling-by-example/shallow-water/novice/4_block_64x4/README.md
+++ b/Profiling-by-example/shallow-water/novice/4_block_64x4/README.md
@@ -74,12 +74,15 @@ in the two streaming kernels, which are the ones that care most about contiguous
 
 ## Roofline
 
+`profile_app.py` in Roofline Extractor needs its
+[Python environment](../README.md#a-python-environment-for-roofline-extractor) active:
+
 ```bash
-module load rocm roofline-extractor
-roofline-extractor-profile -o roofline_out --arch MI300A -- ./shallow
+python3 "$ROOFLINE_EXTRACTOR/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
 ```
 
-The equivalent in `rocprof-compute`:
+The equivalent in `rocprof-compute`, whose `analyze` step needs its
+[Python environment](../README.md#a-python-environment-for-rocprof-compute-analyze) active:
 
 ```bash
 rocprof-compute profile -n 4_block_64x4 --roof-only --device 0 -k compute_rhs --iteration-multiplexing -- ./shallow

--- a/Profiling-by-example/shallow-water/novice/4_block_64x4/fom.sh
+++ b/Profiling-by-example/shallow-water/novice/4_block_64x4/fom.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-4-fom
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=00:30:00
+#SBATCH --output=fom_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+./shallow

--- a/Profiling-by-example/shallow-water/novice/4_block_64x4/profile.sh
+++ b/Profiling-by-example/shallow-water/novice/4_block_64x4/profile.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH --job-name=sw-nov-4-profile
+#SBATCH -N 1
+#SBATCH --gpus=1
+#SBATCH --time=02:00:00
+#SBATCH --output=profile_%j.out
+
+set -e
+STAGE_DIR="${SLURM_SUBMIT_DIR:-$(cd "$(dirname "$0")" && pwd)}"
+SW_ROOT="$(cd "${STAGE_DIR}/../.." && pwd)"
+source "${SW_ROOT}/env.sh"
+
+make clean && make
+
+rocprofv3 --pmc VALUBusy -T --output-format csv -d outdir -o shallow -- ./shallow
+
+rocprofv3 --pmc OccupancyPercent -T --output-format csv -d outdir -o shallow -- ./shallow
+
+if [ "${ROOFLINE_TOOL:-extractor}" = rocprof-compute ]; then
+    rocprof-compute profile -n 4_block_64x4 --overwrite --roof-only --device 0 -k compute_rhs \
+        --iteration-multiplexing -- ./shallow
+    rocprof-compute analyze -p "${STAGE_DIR}/workloads/4_block_64x4/0"
+else
+    : "${ROOFLINE_EXTRACTOR:?Set ROOFLINE_EXTRACTOR in env.sh to your rooflineExtractor checkout}"
+
+    module use /nfsapps/ubuntu-24.04/modules/base 2>/dev/null || true
+    module load roofline-extractor/dev 2>/dev/null || true
+
+    python3 "${ROOFLINE_EXTRACTOR}/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
+fi

--- a/Profiling-by-example/shallow-water/novice/README.md
+++ b/Profiling-by-example/shallow-water/novice/README.md
@@ -144,14 +144,41 @@ line to change.
 
 ### Roofline plots
 
-Every stage shows its roofline twice, once with the Roofline Extractor:
+Every stage shows its roofline twice, once with the Roofline Extractor and once with
+`rocprof-compute`. Novice `profile.sh` runs one backend per job; set
+`ROOFLINE_TOOL` in `env.sh` to `extractor` (default) or `rocprof-compute`.
+
+### A Python environment for roofline extractor
+
+Clone the [Roofline Extractor](https://github.com/AMD-HPC/rooflineExtractor) repo and install its
+Python dependencies once on a login node:
 
 ```bash
-module load rocm roofline-extractor
-roofline-extractor-profile -o roofline_out --arch MI300A -- ./shallow
+git clone https://github.com/AMD-HPC/rooflineExtractor.git ~/rooflineExtractor
+export ROOFLINE_EXTRACTOR=$HOME/rooflineExtractor
+../setup_roofline_extractor_venv.sh
+source ~/roofline-venv/bin/activate
 ```
 
-and once with `rocprof-compute`, whose `analyze` step needs the Python environment below:
+Activate it in any shell where you intend to run `profile_app.py`. On AAC6, point
+`ROOFLINE_EXTRACTOR` at the site install and let `env.sh` activate `~/roofline-venv`; see
+[AAC6.md](../AAC6.md).
+
+Some sites ship a pre-built install or a module wrapper (`roofline-extractor-profile`); those call
+the same `profile_app.py` with Python already configured.
+
+Run `profile_app.py` (Option 1 in the upstream README):
+
+```bash
+python3 "$ROOFLINE_EXTRACTOR/profile_app.py" -o roofline_out --arch MI300A -- ./shallow
+```
+
+Set `--arch` to match your GPU (`MI300A`, `MI300X`, `MI250X`, and others listed in the extractor
+README). The plot is written to `roofline_out/counters.html`.
+
+The rocprof-compute roofline needs the
+[Python environment for `rocprof-compute analyze`](#a-python-environment-for-rocprof-compute-analyze)
+active:
 
 ```bash
 rocprof-compute profile -n 0_baseline --roof-only --device 0 -k compute_rhs --iteration-multiplexing -- ./shallow

--- a/Profiling-by-example/shallow-water/setup_rocprof_compute_venv.sh
+++ b/Profiling-by-example/shallow-water/setup_rocprof_compute_venv.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# One-time setup for rocprof-compute analyze. Run on a login node:
+#   cd Profiling-by-example/shallow-water
+#   ./setup_rocprof_compute_venv.sh
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/env.sh"
+
+python3 -m venv "${ROCprof_COMPUTE_VENV}"
+source "${ROCprof_COMPUTE_VENV}/bin/activate"
+python3 -m pip install -r "${ROCM_PATH}/libexec/rocprofiler-compute/requirements.txt"
+
+echo "Created ${ROCprof_COMPUTE_VENV}"

--- a/Profiling-by-example/shallow-water/setup_roofline_extractor_venv.sh
+++ b/Profiling-by-example/shallow-water/setup_roofline_extractor_venv.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# One-time login-node setup for novice profile.sh on systems without a
+# roofline-extractor module. Clone the repo first, then point ROOFLINE_EXTRACTOR
+# at it in env.sh.
+#
+#   git clone https://github.com/AMD-HPC/rooflineExtractor.git ~/rooflineExtractor
+#   export ROOFLINE_EXTRACTOR=$HOME/rooflineExtractor
+#   ./setup_roofline_extractor_venv.sh
+
+set -e
+SW_ROOT="$(cd "$(dirname "$0")" && pwd)"
+: "${ROOFLINE_EXTRACTOR:?Set ROOFLINE_EXTRACTOR to your rooflineExtractor checkout}"
+
+export ROOFLINE_VENV="${ROOFLINE_VENV:-${HOME}/roofline-venv}"
+
+python3 -m venv "${ROOFLINE_VENV}"
+source "${ROOFLINE_VENV}/bin/activate"
+python3 -m pip install -r "${ROOFLINE_EXTRACTOR}/requirements.txt"
+
+echo "Created ${ROOFLINE_VENV}"

--- a/Profiling-by-example/shallow-water/submit.sh
+++ b/Profiling-by-example/shallow-water/submit.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+source "${ROOT}/env.sh"
+exec sbatch -p "${SLURM_PARTITION}" "$@"


### PR DESCRIPTION
## Summary

Adds Slurm batch scripts and AAC6 site documentation so learners can run the shallow-water profiling tutorials on the cluster without hand-copying commands from each stage README. Also add support for nodes configured with CPX mode.

## Updates

### Batch scripts (novice + advanced)

- `fom.sh` per stage — build, run, print MCUPS / scaling
- `profile.sh` per stage — build, then run that stage's profiling commands (rocprofv3, rocprof-compute, rocprof-sys, ATT as documented)
- `submit.sh` — thin `sbatch` wrapper; partition comes from `env.sh`

### Environment and setup

- `env_aac6.sh` — template for AAC6: modules, partition, NUMA binding (`GPU_BIND` / `MPI_BIND`), roofline paths, venv activation, optional NIC profiling vars
- Root `.gitignore` — ignores local `env.sh`
- `setup_rocprof_compute_venv.sh` — one-time venv for `rocprof-compute analyze`
- `setup_roofline_extractor_venv.sh` — one-time venv for Roofline Extractor (`profile_app.py`)

### Roofline collection

- Novice `profile.sh` selects backend via `ROOFLINE_TOOL` in `env.sh`: `extractor` (default, `profile_app.py`) or `rocprof-compute` (`--roof-only` profile + analyze)
- Docs updated for roofline-extractor and rocprof-compute Python environments; Queue_Id workaround removed (upstream fix verified on AAC6)

### Advanced track helpers

- `gpu_bind_cpx.sh` — single-NUMA GPU binding (CPX layout)
- `nic_trace.sh` — helper for NIC counter profiling (stages 5–6; batch blocks commented until multi-node jobs are available)

### Documentation

- `AAC6.md` — site guide: one-time setup, submission, partition/binding/NIC notes, troubleshooting
- `novice/README.md` — roofline setup section, `ROOFLINE_TOOL` note, venv instructions
- Novice stage READMEs — Python environment callouts before roofline commands
- Top-level `README.md` — link to `AAC6.md`

### `.gitignore`

- `novice/.gitignore` — add Slurm `*.out` logs
- `advanced/.gitignore` — align with batch outputs (ATT, rocprof-sys traces, Slurm logs, compare files, etc.)

## Test plan

- [ ] AAC6: copy `env_aac6.sh` → `env.sh`, run both venv setup scripts, submit `novice/0_baseline/fom.sh` and `profile.sh`
- [ ] Confirm `ROOFLINE_TOOL=extractor` produces `roofline_out/counters.html`
- [ ] Confirm `ROOFLINE_TOOL=rocprof-compute` produces rocprof-compute roofline under `workloads/`
- [ ] Spot-check one advanced stage `profile.sh` on an exclusive 4-GPU node (SPX or CPX binding as appropriate)
