### PR TITLE
tests: drop stray text from rocprof-compute analyze --block line

### DIFF
--- a/tests/rocprof-compute_analyze_check.sh
+++ b/tests/rocprof-compute_analyze_check.sh
@@ -32,4 +32,5 @@ if ! python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3,10) else 1)' 2
   exit 1
 fi
 rocprof-compute profile -n v1 --no-roof -- ./saxpy
-rocprof-compute analyze -p workloads/v1/* --block 7.1.0 7.1.1 7.1.2 7.1.0: Grid size 7.1.1: Workgroup size 7.1.2: Total Wavefronts
+rocprof-compute analyze -p workloads/v1/* --block 7.1.0 7.1.1 7.1.2
+


### PR DESCRIPTION
**What**

`tests/rocprof-compute_analyze_check.sh` ends with:

```
rocprof-compute analyze -p workloads/v1/* --block 7.1.0 7.1.1 7.1.2 7.1.0: Grid size 7.1.1: Workgroup size 7.1.2: Total Wavefronts
```

Everything after `7.1.2` reads like a note, but it's on the command line, so `rocprof-compute` treats those words as additional `--block` values. This trims the line back to the three real block IDs:

```
rocprof-compute analyze -p workloads/v1/* --block 7.1.0 7.1.1 7.1.2
```

**Why**

Newer `rocprof-compute` (3.7.0, shipped with ROCm 7.14.0) validates `--block` values strictly and aborts with `Invalid --block value 7.1.0:`, so the test fails. Older `rocprof-compute` (3.4.0) silently ignores the extra tokens, which is why the test has been passing on machines with the older tool and only started failing on 7.14.0. The three IDs `7.1.0 7.1.1 7.1.2` are exactly what produces the `7.1 Wavefront Launch Stats` block that the CTest check greps for, so the pass condition in `tests/CMakeLists.txt` is unchanged.

**Testing (both a new and an old rocprof-compute)**

- **ROCm 7.14.0 / rocprof-compute 3.7.0:** with the fix, `profile` then `analyze` both succeed and print `7.1 Wavefront Launch Stats`.
- **ROCm 7.2.4 / rocprof-compute 3.4.0:** ran the old and the corrected command back-to-back on the same profiling run — both exit 0 and print `7.1 Wavefront Launch Stats`. So the change is a no-op for the older tool and does not regress it.

No behavior change other than removing the stray tokens; `tests/CMakeLists.txt` is untouched.