### PR TITLE
tests: parse Tcl module show when reading the OpenMPI prefix

### DIFF
--- a/tests/pytorch_comm_backends_check.sh
+++ b/tests/pytorch_comm_backends_check.sh
@@ -83,6 +83,15 @@ if [ -n "${OPENMPI_MODULE_NAME}" ]; then
   if [ -z "${OPENMPI_MODULE_PREFIX}" ]; then
     OPENMPI_MODULE_PREFIX=$(printf '%s\n' "${_show}" | sed -n 's|.*prepend_path("LD_LIBRARY_PATH","\([^"]*\)/lib").*|\1|p' | head -1)
   fi
+  # Tcl Environment Modules: `module show` prints `setenv MPI_PATH <path>` and
+  # `prepend-path LD_LIBRARY_PATH <path>/lib`, not the Lmod Lua forms above.
+  # Only runs if the Lua parse left the prefix empty, so Lmod sites are unchanged.
+  if [ -z "${OPENMPI_MODULE_PREFIX}" ]; then
+    OPENMPI_MODULE_PREFIX=$(printf '%s\n' "${_show}" | sed -n 's/^[[:space:]]*setenv[[:space:]]\{1,\}MPI_PATH[[:space:]]\{1,\}\([^[:space:]]*\).*/\1/p' | head -1)
+    if [ -z "${OPENMPI_MODULE_PREFIX}" ]; then
+      OPENMPI_MODULE_PREFIX=$(printf '%s\n' "${_show}" | sed -n 's|^[[:space:]]*prepend-path[[:space:]]\{1,\}LD_LIBRARY_PATH[[:space:]]\{1,\}\(.*\)/lib[[:space:]]*$|\1|p' | head -1)
+    fi
+  fi
 fi
 export OPENMPI_MODULE_NAME OPENMPI_MODULE_PREFIX
 


### PR DESCRIPTION
**What**

`tests/pytorch_comm_backends_check.sh` reads the loaded `openmpi` module's install
prefix from `module show`, so it can check that `libtorch`'s `libmpi` sits under
that prefix. Today it only matches the **Lmod Lua** forms:

```text
setenv("MPI_PATH","/path")
prepend_path("LD_LIBRARY_PATH","/path/lib")
```

Tcl Environment Modules print:

```text
setenv          MPI_PATH /path
prepend-path    LD_LIBRARY_PATH /path/lib
```

so the Lua `sed` never matches and the test prints the misleading
`could not read the '<mod>' module's install prefix from the modulefile`.

This adds a fallback for the Tcl syntax. It runs only when the Lua parse left
the prefix empty, so Lmod sites do not change.

**Why**

Any site still on Tcl modules hits this (Cray EX with Environment Modules 3.x
is one). The fallback is the same information the test already wants; it does
not relax the GPU-aware MPI check.

This does **not** make the test pass on a PyTorch that links Cray MPICH. After
the prefix is readable, the honest verdict is then
`NO - libtorch links … not under the openmpi module prefix`. A real
`GPU-AWARE MPI: OK` still needs a torch built against that OpenMPI.

**Testing**

- **AAC6 / Lmod 8.6.19 / `rocm/7.14.0`**, job `19549`: stock and patched scripts
  identical; the Tcl fallback did not run (`FALLBACK_RAN=NO`).
- **AAC7 / Tcl Environment Modules**: fallback extracts the OpenMPI prefix
  `/shareddata/opt/rocmplus-ompi-7.14.0/openmpi-5.0.10-libfabric2.3.1-xpmem-2.7.4`.

`tests/CMakeLists.txt` is unchanged.