### PR TITLE
tests: accept staged Cray MPICH in Comm_Backends provenance

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1480,7 +1480,7 @@ set_tests_properties(Pytorch_ROCmSDK_Dlopen_Duplicate_Regression PROPERTIES TIME
 # native RCCL / MPI / UCC / UCX libraries (soname + realpath + version) the
 # build is actually wired to. Needs no GPU or launcher (pure build introspection).
 add_test(NAME Pytorch_Comm_Backends_Check COMMAND ../pytorch_comm_backends_check.sh )
-set_property(TEST Pytorch_Comm_Backends_Check PROPERTY PASS_REGULAR_EXPRESSION "GPU-AWARE MPI: OK")
+set_property(TEST Pytorch_Comm_Backends_Check PROPERTY PASS_REGULAR_EXPRESSION "MPI PROVENANCE: OK")
 set_property(TEST Pytorch_Comm_Backends_Check PROPERTY SKIP_REGULAR_EXPRESSION "module spider" "Unable to locate a modulefile for 'pytorch'" "COMM BACKENDS CHECK: SKIPPED")
 set_property(TEST Pytorch_Comm_Backends_Check PROPERTY SKIP_RETURN_CODE 77)
 set_tests_properties(Pytorch_Comm_Backends_Check PROPERTIES TIMEOUT 300)

--- a/tests/pytorch_comm_backends_check.sh
+++ b/tests/pytorch_comm_backends_check.sh
@@ -356,6 +356,28 @@ print(f"  backends: nccl(RCCL)={avail['nccl']} gloo={avail['gloo']} "
       f"mpi={avail['mpi']} ucc(native)={avail['ucc']}")
 print(f"  default comm path: GPU={defaults.get('cuda')}(RCCL) CPU={defaults.get('cpu')}")
 print(f"GPU-AWARE MPI: {gpu_aware_mpi}")
+# MPI provenance verdict: accept GPU-aware OpenMPI OR Cray/MPICH-family MPI;
+# reject OS/system MPI. Evidence only: resolved libmpi realpath, soname, and
+# MPI_Get_library_version banner. CTest gates on "MPI PROVENANCE: OK".
+mpi_banner_text = mpi_banner(mpi_real) if mpi_real else ""
+mpi_banner_lower = mpi_banner_text.lower()
+mpi_is_os = bool(mpi_real and (mpi_real.startswith(("/usr/", "/lib/", "/lib64/"))
+                              or "site-packages" in mpi_real or "/.libs/" in mpi_real))
+mpi_is_staged_tree = bool(mpi_real and mpi_real.startswith(("/shareddata/", "/opt/cray/", "/opt/rocm")))
+mpi_is_mpich_family = bool(("mpich" in mpi_banner_lower) or re.search(r"libmpi\w*\.so\.12(\.|$)", mpi_name or ""))
+if not avail["mpi"]:
+    mpi_provenance = "NO - MPI backend not compiled in (normal for pip/venv wheels)"
+elif not mpi_real:
+    mpi_provenance = "NO - libtorch does not link libmpi"
+elif under_module and ompi_rocm:
+    mpi_provenance = f"OK - GPU-aware OpenMPI (module '{ompi_mod}', {mpi_name} under {ompi_prefix_real})"
+elif mpi_is_os:
+    mpi_provenance = f"NO - OS/system MPI ({mpi_real}); expected GPU-aware OpenMPI or Cray MPICH"
+elif mpi_is_mpich_family and mpi_is_staged_tree:
+    mpi_provenance = f"OK - Cray MPICH ({mpi_name}, '{mpi_banner_text}', {mpi_real})"
+else:
+    mpi_provenance = f"NO - unrecognised MPI ({mpi_name}, '{mpi_banner_text}', {mpi_real}); not the GPU-aware OpenMPI module and not Cray MPICH"
+print(f"MPI PROVENANCE: {mpi_provenance}")
 sys.exit(0)
 EOF
 


### PR DESCRIPTION
## Summary

This PR adds an `MPI PROVENANCE:` verdict to `Pytorch_Comm_Backends_Check` and
uses that verdict as the CTest pass criterion.

The existing `GPU-AWARE MPI:` line is left unchanged as the strict OpenMPI
diagnostic. The new provenance verdict applies Bob's 3 September rule: pass
when PyTorch is using either GPU-aware OpenMPI from the loaded module or a
staged Cray/MPICH-family MPI, and fail when it resolves to OS/system MPI or an
unrecognised MPI.

## Why

After PR187, Tcl Environment Modules can be parsed correctly, but AAC7 still
fails the original gate honestly because the site PyTorch is linked to staged
Cray MPICH rather than the loaded OpenMPI module. That is not an OS MPI leak.

The new gate keeps the OpenMPI diagnosis visible while changing the CTest
decision to the intended provenance rule.

## Validation

- AAC7 job 10537: standalone `Pytorch_Comm_Backends_Check` passed with
  `MPI PROVENANCE: OK` for staged Cray MPICH.
- AAC7 job 10539: focused Phase C in-harness run passed with the new CTest
  gate, `Regex=[MPI PROVENANCE: OK]`.
- AAC6 job 19659: Lmod/OpenMPI no-regression proof passed. The stock output
  before the new provenance line was identical; with this PR's CTest rule, the
  added `MPI PROVENANCE: OK` line matched the pass expression and the test
  passed.
