### PR TITLE
tests: make Fortran DType tests assert an explicit success marker (fix loose "10" pass regex)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -666,24 +666,24 @@ set_property(TEST OpenMP_Language_Constructs_Fortran_Teams_EndLoop PROPERTY PASS
 set_property(TEST OpenMP_Language_Constructs_Fortran_Teams_EndLoop PROPERTY SKIP_REGULAR_EXPRESSION "module spider")
 
 add_test(NAME OpenMP_Language_Constructs_Fortran_DType_Derived_Type COMMAND ../openmp_language_constructs_fortran_dtype_derived_type.sh )
-set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Derived_Type PROPERTY PASS_REGULAR_EXPRESSION "10")
+set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Derived_Type PROPERTY PASS_REGULAR_EXPRESSION "FORTRAN-DTYPE-RESULT: +10")
 set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Derived_Type PROPERTY SKIP_REGULAR_EXPRESSION "module spider")
 
 add_test(NAME OpenMP_Language_Constructs_Fortran_DType_Derived_Type_Automap COMMAND ../openmp_language_constructs_fortran_dtype_derived_type_automap.sh )
-set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Derived_Type_Automap PROPERTY PASS_REGULAR_EXPRESSION "10")
+set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Derived_Type_Automap PROPERTY PASS_REGULAR_EXPRESSION "FORTRAN-DTYPE-RESULT: +10")
 set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Derived_Type_Automap PROPERTY SKIP_REGULAR_EXPRESSION "module spider")
 
 add_test(NAME OpenMP_Language_Constructs_Fortran_DType_Derived_Type_USM COMMAND ../openmp_language_constructs_fortran_dtype_derived_type_usm.sh )
-set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Derived_Type_USM PROPERTY PASS_REGULAR_EXPRESSION "10")
+set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Derived_Type_USM PROPERTY PASS_REGULAR_EXPRESSION "FORTRAN-DTYPE-RESULT: +10")
 set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Derived_Type_USM PROPERTY SKIP_REGULAR_EXPRESSION "module spider")
 
 add_test(NAME OpenMP_Language_Constructs_Fortran_DType_Pointer COMMAND ../openmp_language_constructs_fortran_dtype_pointer.sh )
-set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Pointer PROPERTY PASS_REGULAR_EXPRESSION "10")
+set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Pointer PROPERTY PASS_REGULAR_EXPRESSION "FORTRAN-DTYPE-RESULT: +10")
 set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Pointer PROPERTY SKIP_REGULAR_EXPRESSION "module spider")
 
 # Known failure
 add_test(NAME OpenMP_Language_Constructs_Fortran_DType_Scalar_Members COMMAND ../openmp_language_constructs_fortran_dtype_scalar_members.sh )
-set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Scalar_Members PROPERTY PASS_REGULAR_EXPRESSION "10")
+set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Scalar_Members PROPERTY PASS_REGULAR_EXPRESSION "FORTRAN-DTYPE-RESULT: +10")
 set_property(TEST OpenMP_Language_Constructs_Fortran_DType_Scalar_Members PROPERTY SKIP_REGULAR_EXPRESSION "module spider")
 
 add_test(NAME OpenMP_Language_Constructs_C_Reduction_Scalar COMMAND ../openmp_language_constructs_c_reduction_scalar.sh )

--- a/tests/openmp_language_constructs_fortran_dtype_derived_type.sh
+++ b/tests/openmp_language_constructs_fortran_dtype_derived_type.sh
@@ -35,5 +35,12 @@ cp * ${BUILD_DIR}
 
 cd ${BUILD_DIR}
 
+# Fail visibly if the build or run fails, then emit an explicit success
+# marker from the real executable output so CTest matches the marker, not a
+# bare "10" that any path/build-name containing 10 could satisfy.
+set -euo pipefail
+
 make dtype_derived_type
-./dtype_derived_type
+out="$(./dtype_derived_type)"
+echo "$out"
+echo "FORTRAN-DTYPE-RESULT: $(awk 'NF {last=$0} END {print last}' <<< "$out")"

--- a/tests/openmp_language_constructs_fortran_dtype_derived_type_automap.sh
+++ b/tests/openmp_language_constructs_fortran_dtype_derived_type_automap.sh
@@ -35,5 +35,12 @@ cp * ${BUILD_DIR}
 
 cd ${BUILD_DIR}
 
+# Fail visibly if the build or run fails, then emit an explicit success
+# marker from the real executable output so CTest matches the marker, not a
+# bare "10" that any path/build-name containing 10 could satisfy.
+set -euo pipefail
+
 make dtype_derived_type_automap
-./dtype_derived_type_automap
+out="$(./dtype_derived_type_automap)"
+echo "$out"
+echo "FORTRAN-DTYPE-RESULT: $(awk 'NF {last=$0} END {print last}' <<< "$out")"

--- a/tests/openmp_language_constructs_fortran_dtype_derived_type_usm.sh
+++ b/tests/openmp_language_constructs_fortran_dtype_derived_type_usm.sh
@@ -35,5 +35,12 @@ cp * ${BUILD_DIR}
 
 cd ${BUILD_DIR}
 
+# Fail visibly if the build or run fails, then emit an explicit success
+# marker from the real executable output so CTest matches the marker, not a
+# bare "10" that any path/build-name containing 10 could satisfy.
+set -euo pipefail
+
 make dtype_derived_type_usm
-./dtype_derived_type_usm
+out="$(./dtype_derived_type_usm)"
+echo "$out"
+echo "FORTRAN-DTYPE-RESULT: $(awk 'NF {last=$0} END {print last}' <<< "$out")"

--- a/tests/openmp_language_constructs_fortran_dtype_pointer.sh
+++ b/tests/openmp_language_constructs_fortran_dtype_pointer.sh
@@ -25,7 +25,6 @@ fi
 
 REPO_DIR="$(dirname "$(dirname "$(readlink -fm "$0")")")"
 cd ${REPO_DIR}/Pragma_Examples/OpenMP/Fortran/7_derived_types
-cd derived_types
 
 SRC_DIR=$(pwd)
 BUILD_DIR=$(mktemp -d)
@@ -34,5 +33,12 @@ cp * ${BUILD_DIR}
 
 cd ${BUILD_DIR}
 
+# Fail visibly if the build or run fails, then emit an explicit success
+# marker from the real executable output so CTest matches the marker, not a
+# bare "10" that any path/build-name containing 10 could satisfy.
+set -euo pipefail
+
 make dtype_pointer
-./dtype_pointer
+out="$(./dtype_pointer)"
+echo "$out"
+echo "FORTRAN-DTYPE-RESULT: $(awk 'NF {last=$0} END {print last}' <<< "$out")"

--- a/tests/openmp_language_constructs_fortran_dtype_scalar_members.sh
+++ b/tests/openmp_language_constructs_fortran_dtype_scalar_members.sh
@@ -34,5 +34,12 @@ cp * ${BUILD_DIR}
 
 cd ${BUILD_DIR}
 
+# Fail visibly if the build or run fails, then emit an explicit success
+# marker from the real executable output so CTest matches the marker, not a
+# bare "10" that any path/build-name containing 10 could satisfy.
+set -euo pipefail
+
 make dtype_scalar_members
-./dtype_scalar_members
+out="$(./dtype_scalar_members)"
+echo "$out"
+echo "FORTRAN-DTYPE-RESULT: $(awk 'NF {last=$0} END {print last}' <<< "$out")"


### PR DESCRIPTION
## What

The five `OpenMP_Language_Constructs_Fortran_DType_*` CTest entries gate on a loose `PASS_REGULAR_EXPRESSION "10"`. A bare `10` can be matched by output unrelated to the test result, for example a build path or dashboard build name that contains `10` such as `moduleset10`, so a test can report PASS without the executable ever producing the correct answer.

This change makes the pass criterion honest:

- Each `tests/openmp_language_constructs_fortran_dtype_*.sh` now runs the real executable, prints its output, and emits an explicit marker: `FORTRAN-DTYPE-RESULT: <last non-empty output line>`.
- `tests/CMakeLists.txt` matches `FORTRAN-DTYPE-RESULT: +10` instead of `10`. The `+` tolerates Fortran list-directed leading spaces, for example `RESULT:  10`.
- The scripts add `set -euo pipefail` after the existing module-detection block, so a failed build or a nonzero executable exit fails the test visibly instead of silently.
- The pointer test drops a stray `cd derived_types`; there is no `7_derived_types/derived_types` directory, and under `set -e` that failed `cd` must not remain.

## Why

A pass regex of `10` is trivially satisfied by unrelated text and hides real build/run failures. Matching an explicit marker printed from the executable output makes these tests trustworthy.

## Validation

AAC7: MI300A / gfx942, focused no-submit run:

```bash
cd tests && rm -rf build && cmake . -B build
ctest -V -R '^OpenMP_Language_Constructs_Fortran_DType' --test-dir build
```

Result: 5/5 pass, each via the explicit marker `FORTRAN-DTYPE-RESULT:  10`; `100% tests passed, 0 tests failed out of 5`. Confirmed the new regex does not match a `moduleset10`-style path while the old `10` did.

AAC6 no-regression: PASS, Slurm job 19708 on ppac-pl1-s24-16 / PPAC_MI300A_SPX, 5/5 Fortran DType tests passed with `FORTRAN-DTYPE-RESULT:  10`.