### PR TITLE
Pragma_Examples: fix Fortran min/max/sum array reduction test discarding its device result

### DIFF
--- a/Pragma_Examples/OpenMP/Fortran/5_reduction_array/2_reduction_array_min_max_sum/reduction.f90
+++ b/Pragma_Examples/OpenMP/Fortran/5_reduction_array/2_reduction_array_min_max_sum/reduction.f90
@@ -19,13 +19,11 @@ program rt003_reduction
   iarr = (/ 258, 290, 320, 258 /)
 
   imax_result = -huge(imax_result)
-  !$omp target
-  !$omp teams loop collapse(1) default(shared) private(i) reduction(MAX: imax_result)
+  !$omp target teams loop collapse(1) default(shared) private(i) reduction(MAX: imax_result)
   do i = 1, n, 1
     imax_result = max(imax_result, iarr(i))
   end do
-  !$omp end teams loop
-  !$omp end target
+  !$omp end target teams loop
 
   write(*,'(a,i0,a,i0)') "Test 1  int MAX (n=4):       result=", imax_result, "  expected=", 320
   if (imax_result /= 320) then
@@ -47,13 +45,11 @@ program rt003_reduction
   iarr(512) = 99999
 
   imax_result = -huge(imax_result)
-  !$omp target
-  !$omp teams loop collapse(1) default(shared) private(i) reduction(MAX: imax_result)
+  !$omp target teams loop collapse(1) default(shared) private(i) reduction(MAX: imax_result)
   do i = 1, n, 1
     imax_result = max(imax_result, iarr(i))
   end do
-  !$omp end teams loop
-  !$omp end target
+  !$omp end target teams loop
 
   write(*,'(a,i0,a,i0)') "Test 2  int MAX (n=1024):    result=", imax_result, "  expected=", 99999
   if (imax_result /= 99999) then
@@ -75,13 +71,11 @@ program rt003_reduction
   iarr(100) = -42
 
   imin_result = huge(imin_result)
-  !$omp target
-  !$omp teams loop collapse(1) default(shared) private(i) reduction(MIN: imin_result)
+  !$omp target teams loop collapse(1) default(shared) private(i) reduction(MIN: imin_result)
   do i = 1, n, 1
     imin_result = min(imin_result, iarr(i))
   end do
-  !$omp end teams loop
-  !$omp end target
+  !$omp end target teams loop
 
   write(*,'(a,i0,a,i0)') "Test 3  int MIN (n=256):     result=", imin_result, "  expected=", -42
   if (imin_result /= -42) then
@@ -102,13 +96,11 @@ program rt003_reduction
   end do
 
   isum_result = 0
-  !$omp target
-  !$omp teams loop collapse(1) default(shared) private(i) reduction(+: isum_result)
+  !$omp target teams loop collapse(1) default(shared) private(i) reduction(+: isum_result)
   do i = 1, n, 1
     isum_result = isum_result + iarr(i)
   end do
-  !$omp end teams loop
-  !$omp end target
+  !$omp end target teams loop
 
   write(*,'(a,i0,a,i0)') "Test 4  int SUM (n=100):     result=", isum_result, "  expected=", 5050
   if (isum_result /= 5050) then
@@ -130,13 +122,11 @@ program rt003_reduction
   darr(256) = 9999.0d0
 
   dmax_result = -huge(dmax_result)
-  !$omp target
-  !$omp teams loop collapse(1) default(shared) private(i) reduction(MAX: dmax_result)
+  !$omp target teams loop collapse(1) default(shared) private(i) reduction(MAX: dmax_result)
   do i = 1, n, 1
     dmax_result = max(dmax_result, darr(i))
   end do
-  !$omp end teams loop
-  !$omp end target
+  !$omp end target teams loop
 
   write(*,'(a,f12.2,a,f12.2)') "Test 5  dp  MAX (n=512):     result=", dmax_result, "  expected=", 9999.0d0
   if (abs(dmax_result - 9999.0d0) > 1.0d-6) then
@@ -158,13 +148,11 @@ program rt003_reduction
   darr(300) = -7777.0d0
 
   dmin_result = huge(dmin_result)
-  !$omp target
-  !$omp teams loop collapse(1) default(shared) private(i) reduction(MIN: dmin_result)
+  !$omp target teams loop collapse(1) default(shared) private(i) reduction(MIN: dmin_result)
   do i = 1, n, 1
     dmin_result = min(dmin_result, darr(i))
   end do
-  !$omp end teams loop
-  !$omp end target
+  !$omp end target teams loop
 
   write(*,'(a,f12.2,a,f12.2)') "Test 6  dp  MIN (n=512):     result=", dmin_result, "  expected=", -7777.0d0
   if (abs(dmin_result - (-7777.0d0)) > 1.0d-6) then
@@ -185,13 +173,11 @@ program rt003_reduction
   end do
 
   dsum_result = 0.0d0
-  !$omp target
-  !$omp teams loop collapse(1) default(shared) private(i) reduction(+: dsum_result)
+  !$omp target teams loop collapse(1) default(shared) private(i) reduction(+: dsum_result)
   do i = 1, n, 1
     dsum_result = dsum_result + darr(i)
   end do
-  !$omp end teams loop
-  !$omp end target
+  !$omp end target teams loop
 
   write(*,'(a,f12.2,a,f12.2)') "Test 7  dp  SUM (n=1000):    result=", dsum_result, "  expected=", 1000.0d0
   if (abs(dsum_result - 1000.0d0) > 1.0d-6) then
@@ -210,15 +196,13 @@ program rt003_reduction
   iarr = (/ 258, 290, 320, 258 /)
 
   imax_result = -huge(imax_result)
-  !$omp target
-  !$omp teams loop collapse(1) default(shared) private(i) reduction(MAX: imax_result)
+  !$omp target teams loop collapse(1) default(shared) private(i) reduction(MAX: imax_result)
   do i = 1, n, 1
     if (iarr(i) > 0) then
       imax_result = max(imax_result, iarr(i))
     end if
   end do
-  !$omp end teams loop
-  !$omp end target
+  !$omp end target teams loop
 
   write(*,'(a,i0,a,i0)') "Test 8  int MAX cond (n=4):  result=", imax_result, "  expected=", 320
   if (imax_result /= 320) then

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -648,7 +648,6 @@ add_test(NAME OpenMP_Language_Constructs_Fortran_Reduction_Array COMMAND ../open
 set_property(TEST OpenMP_Language_Constructs_Fortran_Reduction_Array PROPERTY PASS_REGULAR_EXPRESSION "Form 1 \\(whole array\\)   : ce\\(1\\) = 1000.000000000000  ce\\(2\\) = 1000.000000000000")
 set_property(TEST OpenMP_Language_Constructs_Fortran_Reduction_Array PROPERTY SKIP_REGULAR_EXPRESSION "module spider")
 
-# Expected failure -- not implemented in amdflang-new yet
 add_test(NAME OpenMP_Language_Constructs_Fortran_Reduction_Array_Min_Max_Sum COMMAND ../openmp_language_constructs_fortran_2_reduction_array_min_max_sum.sh )
 set_property(TEST OpenMP_Language_Constructs_Fortran_Reduction_Array_Min_Max_Sum PROPERTY PASS_REGULAR_EXPRESSION "ALL TESTS PASSED")
 set_property(TEST OpenMP_Language_Constructs_Fortran_Reduction_Array_Min_Max_Sum PROPERTY SKIP_REGULAR_EXPRESSION "module spider")


### PR DESCRIPTION
## What

`Pragma_Examples/OpenMP/Fortran/5_reduction_array/2_reduction_array_min_max_sum/reduction.f90`
reports the wrong answer for all eight of its sub-tests. Each one reports the
initialiser of its result variable rather than the reduction: `Test 1 int MAX`
prints the value of `-huge(imax_result)`, `Test 4 int SUM` prints `0`, and so on.

All eight sub-tests use a bare `!$omp target` with the reduction on an inner
`!$omp teams loop`:

    !$omp target
    !$omp teams loop collapse(1) default(shared) private(i) reduction(MAX: imax_result)
    ...
    !$omp end teams loop
    !$omp end target

A scalar referenced in a `target` region with no `map` or `defaultmap` clause is
firstprivate, so the value is copied in and never copied back. The device
performs the reduction correctly and the host then discards the result.

This change uses the combined construct instead, which is what the passing
sibling test `OpenMP_Language_Constructs_Fortran_Reduction_Array` already does:

    !$omp target teams loop collapse(1) default(shared) private(i) reduction(MAX: imax_result)
    ...
    !$omp end target teams loop

The change also removes this annotation above the test in `tests/CMakeLists.txt`:

    # Expected failure -- not implemented in amdflang-new yet

That comment is a mis-diagnosis. The construct is implemented and the reduction is
computed correctly; only the data mapping was wrong.

## Why

The test currently fails for a reason that has nothing to do with compiler
support, while an annotation in the test list attributes the failure to a missing
compiler feature. Anyone reading it learns the wrong lesson twice: that this
reduction form is unsupported, and that the code as written is correct.

## Validation

MI300A / gfx942, `HSA_XNACK=1`, `amdflang` from `$ROCM_PATH/bin`. Focused run on
upstream `main` (`20e93223`):

    git clone https://github.com/amd/HPCTrainingExamples.git
    cd HPCTrainingExamples/tests
    export HSA_XNACK=1
    export ROCM_GPU=gfx942
    export FC="${ROCM_PATH}/bin/amdflang"
    rm -rf build && cmake . -B build
    ctest -V -R '^OpenMP_Language_Constructs_Fortran_Reduction_Array_Min_Max_Sum$' --test-dir build

On many raw clones the CTest driver does not pick up `amdflang` unless `FC` is set
explicitly as above.

**Unpatched upstream:** 1/1 FAIL. All eight sub-tests report wrong answers
(initialiser values); CTest misses the `ALL TESTS PASSED` regex.

**With this change:** 1/1 PASS. Example lines:

    Test 1  int MAX (n=4):       result=320  expected=320
    Test 4  int SUM (n=100):     result=5050  expected=5050
    Test 7  dp  SUM (n=1000):    result=     1000.00  expected=     1000.00
    Test 8  int MAX cond (n=4):  result=320  expected=320
    ALL TESTS PASSED

AAC7 proof: current-main CTest on ROCm 10.0.0 — unpatched FAIL, patched PASS.

AAC6 no-regression: MI300A, Lmod `rocm/7.14.0`, Slurm job `19739` on
`ppac-pl1-s24-16` — 1/1 PASS, `ALL TESTS PASSED`, with
`FC=$ROCM_PATH/bin/amdflang`.
