### PR TITLE
HIPStdPar: add -Wl,-rpath next to -L$(TBB_LIBDIR) in MixAndMatch std_cpu_gpu

### DIFF
--- a/HIPStdPar/CXX/MixAndMatch/std_cpu_gpu/Makefile
+++ b/HIPStdPar/CXX/MixAndMatch/std_cpu_gpu/Makefile
@@ -35,7 +35,7 @@ stdpar_gpu_executor.o: stdpar_gpu_executor.cpp
 
 # Link all object files and main.cpp into final
 $(TARGET): $(OBJS) main.cpp
-	$(HIPCC) $(CXXFLAGS) $(OPENMP_FLAGS) $(OBJS) main.cpp -o $@ -L$(TBB_LIBDIR) ${LIBS} -ltbb
+	$(HIPCC) $(CXXFLAGS) $(OPENMP_FLAGS) $(OBJS) main.cpp -o $@ -L$(TBB_LIBDIR) -Wl,-rpath,$(TBB_LIBDIR) ${LIBS} -ltbb
 
 clean:
 	rm -f $(OBJS) $(TARGET)


### PR DESCRIPTION
## What

`HIPStdPar/CXX/MixAndMatch/std_cpu_gpu/Makefile` passes the TBB directory to the
linker with `-L` only:

    $(HIPCC) ... -o $@ -L$(TBB_LIBDIR) ${LIBS} -ltbb

`-L` is a link-time search path. It does not end up in the binary, so the dynamic
loader has no idea where TBB lives. This change adds the matching rpath:

    $(HIPCC) ... -o $@ -L$(TBB_LIBDIR) -Wl,-rpath,$(TBB_LIBDIR) ${LIBS} -ltbb

## Why

On a machine with no TBB in the default loader path, the test links without
complaint and then fails to start:

    ./final: error while loading shared libraries: libtbb.so.12: cannot open shared object file

The Makefile already detects TBB and already knows the directory, including the
copy ROCm ships under `lib/rocprofiler-systems`, which is not on the default
loader path. Nothing else is needed; the directory just has to be recorded in the
binary as well as used at link time.

## Validation

MI300A / gfx942, ROCm with HIPStdPar. Focused run on upstream `main` (`20e93223`):

    git clone https://github.com/amd/HPCTrainingExamples.git
    cd HPCTrainingExamples/tests
    export HSA_XNACK=1
    export ROCM_GPU=gfx942
    rm -rf build && cmake . -B build
    ctest -V -R '^HIPStdPar_MixAndMatch_CpuGpu$' --test-dir build

Environment details from the validation jobs:

AAC7 focused proof, job `10628`:

    PrgEnv-amd-openmpi/openmpi-5.0.10-ofi-10.0.0
    rocm/10.0.0
    craype-accel-amd-gfx942
    cray-python
    ROCM_PATH=/shareddata/opt/rocm-10.0.0
    HSA_XNACK=1
    hipcc=/shareddata/opt/rocm-10.0.0/bin/hipcc
    TBB_LIBDIR=/shareddata/opt/rocm-10.0.0/lib/rocprofiler-systems

AAC6 no-regression, job `19740`:

    module system: Lmod 8.6.19
    loaded modules: rocm/7.14.0
    ROCM_PATH=/nfsapps/ubuntu-24.04/opt/rocm-7.14.0
    HSA_XNACK=1
    ROCM_GPU=gfx942
    HIP compiler: hipcc / AMD clang 23.0.0git
    CDASH_SUBMIT=0

**Unpatched upstream:** 1/1 FAIL. The binary records no RUNPATH; `ldd` reports
`libtbb.so.12 => not found`; CTest fails at launch with the loader error above.

**With this change:** 1/1 PASS. Example success marker:

    RUNPATH  [<rocm>/lib/rocprofiler-systems]
    StdParGpu Executor took 473 ms

AAC7 proof: current-main CTest on ROCm 10.0.0 — unpatched FAIL, patched PASS.

AAC6 no-regression: MI300A, Lmod `rocm/7.14.0`, Slurm job `19740` on
`ppac-pl1-s24-16` — 1/1 PASS (`StdParGpu Executor took 473 ms`).
